### PR TITLE
Correct logic for inlineShortcuts override. Fixes #23.

### DIFF
--- a/src/editor/editor-shortcuts.js
+++ b/src/editor/editor-shortcuts.js
@@ -563,7 +563,7 @@ function matchEndOf(s, config) {
     if (customInlineShortcuts) {
         for (const k in customInlineShortcuts) {
             if (customInlineShortcuts.hasOwnProperty(k)) {
-                if (k.length >= matchLength && s.substr(-k.length) == k) {
+                if (k.length >= matchLength && s.substr(-k.length) === k) {
                     result = {
                         match: k,
                         substitute: customInlineShortcuts[k]

--- a/src/editor/editor-shortcuts.js
+++ b/src/editor/editor-shortcuts.js
@@ -563,7 +563,7 @@ function matchEndOf(s, config) {
     if (customInlineShortcuts) {
         for (const k in customInlineShortcuts) {
             if (customInlineShortcuts.hasOwnProperty(k)) {
-                if (k.length > matchLength && s.substr(-k.length) === k) {
+                if (k.length >= matchLength && s.substr(-k.length) == k) {
                     result = {
                         match: k,
                         substitute: customInlineShortcuts[k]


### PR DESCRIPTION
If overriding a default, the string lengths will be equal, so the test should be `>=`, not `>`. Also, it seems one of the strings is created with 'new', so `==` works but  `===` doesn't. I didn't look into the details, but that tweak caused the comparison to be true.