### PR TITLE
Accessibility

### DIFF
--- a/css/mathlive.core.less
+++ b/css/mathlive.core.less
@@ -57,6 +57,16 @@ to make sure it doesn't show. */
     /*-ms-transform: scale(0);*/
 }
 
+.ML__HiddenAccessibleMath {
+    clip: rect(1px, 1px, 1px, 1px);
+    position: absolute !important;
+    white-space: nowrap;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+}
+
+
 .ML__fieldcontainer {
     display: flex;
     flex-flow: row;

--- a/src/addons/auto-render.js
+++ b/src/addons/auto-render.js
@@ -124,49 +124,71 @@ function splitWithDelimiters(text, delimiters) {
 }
 
 
-function createAccessibleNode(latex, mathstyle) {
+function createAccessibleNode(latex, mathstyle, latexToMarkup) {
     // Create a node for AT to speak, etc.
     // This node has a style that makes it be invisible to display but is seen by AT
     // FIX: Currently this is text, but once MathML support is added, it should be MathML
-
-    /* this style should be in the CSS
-    .MathMLNoDisplay {
-        clip: rect(1px, 1px, 1px, 1px);
-        position: absolute !important;
-        white-space: nowrap;
-        height: 1px;
-        width: 1px;
-        overflow: hidden;
+    const span = document.createElement('span');
+    try {
+        span.innerText = MathAtom.toSpeakableText(latexToMarkup(latex, mathstyle, 'mathlist'));   
+    } catch (e) {
+        console.error( 'Could not convert\'' + latex + '\' to accessible format with ', e );
+        span.innerText = latex;   
     }
-    */
-    let elem = document.createElement('span');
-    elem.innerText = MathAtom.toSpeakableText(MathLive.latexToMarkup(latex, mathstyle, 'mathlist'));
-    elem.setAttribute('class', 'MathMLNoDisplay');
-    elem.setAttribute('style', 'clip: rect(1px, 1px, 1px, 1px); position: absolute !important;white-space: nowrap; height: 1px; width: 1px; overflow: hidden;');
-    console.log(elem.outerHTML);
-    return elem;
+    span.setAttribute('class', 'ML__HiddenAccessibleMath');
+    return span;
 }
+
+function createMarkupNode(text, options, mathstyle, latexToMarkup, createNodeOnFailure) {
+    // Create a node for displaying math.
+    //   This is slightly ugly because in the case of failure to create the markup,
+    //   sometimes a text node is desired and sometimes not.
+    //   'createTextNodeOnFailure' controls this and null is returned when no node is created.
+    // This node is made invisible to AT
+    let span = document.createElement('span');
+    span.setAttribute('aria-hidden','true');
+    if (options.preserveOriginalContent) {
+        span.setAttribute('data-' + options.namespace + 'original-content', text);
+        if (mathstyle) {
+            span.setAttribute('data-' + options.namespace + 'original-mathstyle', mathstyle);
+        }
+    }
+
+    try {
+        span.innerHTML = latexToMarkup(text, mathstyle || 'displaystyle');
+     } catch (e) {
+        console.error( 'Could not parse\'' + text + '\' with ', e );
+        if (createNodeOnFailure) {
+            span = document.createTextNode(text);
+        } else {
+            return null;
+        }
+    }
+    return span;
+}
+
+function createAccessibleMarkupPair(text, mathstyle, options, latexToMarkup, createNodeOnFailure) {
+    // Create a math node (a span with an accessible component and a visual component)
+    // If there is an error in parsing the latex, 'createNodeOnFailure' controls whether
+    //   'null' is returned or an accessible node with the text used.
+    const markupNode = createMarkupNode(text, options, mathstyle, latexToMarkup, createNodeOnFailure);
+    if (markupNode === null) {
+        return null;
+    }
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(createAccessibleNode(text, mathstyle || 'displaystyle', latexToMarkup));
+    fragment.appendChild(markupNode);
+    return fragment;    
+}
+
 function scanText(text, options, latexToMarkup) {
     // If the text starts with '\begin'...
     // (this is a MathJAX behavior)
     let fragment = null;
     if (options.TeX.processEnvironments && text.match(/^\s*\\begin/)) {
         fragment = document.createDocumentFragment();
-        const span = document.createElement('span');
-        span.setAttribute('aria-hidden','true');
-        if (options.preserveOriginalContent) {
-            span.setAttribute('data-' + options.namespace + 'original-content', text);
-        }
-        try {
-            span.innerHTML = latexToMarkup(text, 'displaystyle');
-            fragment.appendChild(span);
-            fragment.appendChild(createAccessibleNode(text, 'displaystyle'))
-       } catch (e) {
-            console.error(
-                'Could not parse\'' + text + '\' with ', e
-            );
-            fragment.appendChild(document.createTextNode(text));
-        }
+        fragment.appendChild(createAccessibleMarkupPair(text, undefined, options, latexToMarkup, true));
     } else {
         const data = splitWithDelimiters(text, options.TeX.delimiters);
         if (data.length === 1 && data[0].type === 'text') {
@@ -179,22 +201,7 @@ function scanText(text, options, latexToMarkup) {
             if (data[i].type === 'text') {
                 fragment.appendChild(document.createTextNode(data[i].data));
             } else {
-                const span = document.createElement('span');
-                span.setAttribute('aria-hidden','true');
-                if (options.preserveOriginalContent) {
-                    span.setAttribute('data-' + options.namespace + 'original-content', data[i].data);
-                }
-                try {
-                    span.innerHTML = latexToMarkup(data[i].data, data[i].mathstyle);
-                    fragment.appendChild(span);
-                    fragment.appendChild(createAccessibleNode(data[i].data, data[i].mathstyle));
-                } catch (e) {
-                    console.error(
-                        'Could not parse\'' + data[i].data + '\' with ', e
-                    );
-                    fragment.appendChild(document.createTextNode(data[i].rawData));
-                    continue;
-                }
+                fragment.appendChild(createAccessibleMarkupPair(data[i].data, data[i].mathstyle, options, latexToMarkup, true));
             }
         }
     }
@@ -202,145 +209,85 @@ function scanText(text, options, latexToMarkup) {
 }
 
 function scanElement(elem, options, latexToMarkup) {
-    let handled = false;
     const originalContent = elem.getAttribute('data-' + options.namespace + 
         'original-content');
     if (originalContent) {
-        const mathstyle = elem.getAttribute('data-' + options.namespace + 
-            'mathstyle') || 'displaystyle';
-        try {
-            const span = document.createElement('span');
-            span.appendChild(latexToMarkup(originalContent, mathstyle));
-            span.appendChild(createAccessibleNode(originalContent, mathstyle));
+        const mathstyle = elem.getAttribute('data-' + options.namespace + 'mathstyle');
+        const span = createAccessibleMarkupPair(originalContent, mathstyle, options, latexToMarkup, false);
+        if (span != null) {
             elem.textContent = '';
             elem.appendChild(span);
-        } catch (e) {
-            console.error(
-                'Could not parse\'' + originalContent + '\' with ', e
-            );
         }
-        handled = true;
-    } else if (elem.childNodes.length === 1 && elem.childNodes[0].nodeType === 3) {
+        return;
+    }
+        
+    
+    if (elem.childNodes.length === 1 && elem.childNodes[0].nodeType === 3) {
         // This is a node with textual content only. Perhaps an opportunity
         // to simplify and avoid creating extra nested elements...
         const text = elem.childNodes[0].textContent;
-        let innerContent;
-        let mathstyle;
         if (options.TeX.processEnvironments && text.match(/^\s*\\begin/)) {
-            try {
-                innerContent = latexToMarkup(text, 'displaystyle');
-            } catch (e) {
-                console.error(
-                    'Could not parse\'' + text + '\' with ', e
-                );
-                innerContent = text;
-            }
-        } 
-        if (!innerContent) {
-            const data = splitWithDelimiters(text, options.TeX.delimiters);
-            if (data.length === 1 && data[0].type === 'math') {
-                // The entire content is a math expression: we can replace the content
-                // with the latex markup without creating additional wrappers.
-                try {
-                    mathstyle = data[0].mathstyle;
-                    innerContent = latexToMarkup(data[0].data, mathstyle);
-                } catch (e) {
-                    console.error(
-                        'Could not parse\'' + data[0].data + '\' with ', e
-                    );
-                    innerContent = data[0].data;
-                }
-            } else if (data.length === 1 && data[0].type === 'text') {
-                // This element only contained text with no math. No need to 
-                // do anything.
-                handled = true;
-            }
-        }
-        if (innerContent) {
-            let span = document.createElement('span');            
-            span.innerHTML = innerContent;
-            span.firstChild.setAttribute('aria-hidden','true');
-           if (options.preserveOriginalContent) {
-                span.setAttribute('data-' + options.namespace + 'original-content', text);
-                if (mathstyle) {
-                    span.setAttribute('data-' + options.namespace + 'original-mathstyle', mathstyle);
-                }
-            }
-            span.appendChild(createAccessibleNode(text, mathstyle));
             elem.textContent = '';
-            elem.appendChild(span);
-            handled = true;
+            elem.appendChild( createAccessibleMarkupPair(originalContent, undefined, options, latexToMarkup, true) );
+            return;
         }
+
+        const data = splitWithDelimiters(text, options.TeX.delimiters);
+        if (data.length === 1 && data[0].type === 'math') {
+            // The entire content is a math expression: we can replace the content
+            // with the latex markup without creating additional wrappers.
+            elem.textContent = '';
+            elem.appendChild( createAccessibleMarkupPair(data[0].data, data[0].mathstyle, options, latexToMarkup, true) );
+        } else if (data.length === 1 && data[0].type === 'text') {
+            // This element only contained text with no math. No need to 
+            // do anything.
+        }
+        return;
     }
-    if (!handled) {
-        for (let i = 0; i < elem.childNodes.length; i++) {
-            const childNode = elem.childNodes[i];
-            if (childNode.nodeType === 3) {
-                // A text node
-                // Look for math mode delimiters inside the text
-                const frag = scanText(childNode.textContent, options, latexToMarkup);
-                if (frag) {
-                    i += frag.childNodes.length - 1;
-                    elem.replaceChild(frag, childNode);
-                }
-            } else if (childNode.nodeType === 1) {
-                // An element node
-                const tag = childNode.nodeName.toLowerCase();
-                if (tag === 'script' && 
-                    options.processScriptTypePattern.test(childNode.type)) {
-                    let style = 'displaystyle';
-                    for (const l of  childNode.type.split(';')) {
-                        const v = l.split('=');
-                        if (v[0].toLowerCase() === 'mode') {
-                            if (v[1].toLoweCase() === 'display') {
-                                style = 'displaystyle'; 
-                            } else {
-                                style = 'textstyle';
-                            }
 
+    for (let i = 0; i < elem.childNodes.length; i++) {
+        const childNode = elem.childNodes[i];
+        if (childNode.nodeType === 3) {
+            // A text node
+            // Look for math mode delimiters inside the text
+            const frag = scanText(childNode.textContent, options, latexToMarkup);
+            if (frag) {
+                i += frag.childNodes.length - 1;
+                elem.replaceChild(frag, childNode);
+            }
+        } else if (childNode.nodeType === 1) {
+            // An element node
+            const tag = childNode.nodeName.toLowerCase();
+            if (tag === 'script' && 
+                options.processScriptTypePattern.test(childNode.type)) {
+                let style = 'displaystyle';
+                for (const l of  childNode.type.split(';')) {
+                    const v = l.split('=');
+                    if (v[0].toLowerCase() === 'mode') {
+                        if (v[1].toLoweCase() === 'display') {
+                            style = 'displaystyle'; 
+                        } else {
+                            style = 'textstyle';
                         }
+
                     }
+                }
 
-                    // for convenience, create a wrapper around the displayed and accessible math
-                    const outterSpan = document.createElement('span');
+                const span = createAccessibleMarkupPair(childNode.textContent, style, options, latexToMarkup, true)
+                childNode.parentNode.replaceChild(span, childNode);
+            } else {
+                // Element node
+                const shouldRender = 
+                    options.processClassPattern.test(childNode.className) ||
+                    !(options.skipTags.includes(tag) || 
+                        options.ignoreClassPattern.test(childNode.className));
 
-                    const span = document.createElement('span');
-                    span.setAttribute('aria-hidden','true');
-
-                    try {
-                        span.innerHTML = latexToMarkup(childNode.textContent, style);
-                    } catch(e) {
-                        console.error(
-                            'Could not parse\'' + childNode.textContent + '\' with ', e
-                        );
-                        span.innerHTML = childNode.textContent;
-                    }
-                    if (options.preserveOriginalContent) {
-                        span.setAttribute('data-' + options.namespace + 
-                            'original-content', childNode.textContent);
-                        span.setAttribute('data-' + options.namespace + 
-                            'mathstyle', style);
-                        
-                    }
-                        
-                    childNode.appendChild(createAccessibleNode(childNode.textContent, style));
-
-                    childNode.appendChild(span);
-                    childNode.parentNode.replaceChild(outterSpan, childNode);
-                } else {
-                    // Element node
-                    const shouldRender = 
-                        options.processClassPattern.test(childNode.className) ||
-                        !(options.skipTags.includes(tag) || 
-                            options.ignoreClassPattern.test(childNode.className));
-
-                    if (shouldRender) {
-                        scanElement(childNode, options, latexToMarkup);
-                    }
+                if (shouldRender) {
+                    scanElement(childNode, options, latexToMarkup);
                 }
             }
-            // Otherwise, it's something else, and ignore it.
         }
+        // Otherwise, it's something else, and ignore it.
     }
 }
 

--- a/src/addons/outputSpokenText.js
+++ b/src/addons/outputSpokenText.js
@@ -222,7 +222,7 @@ function emph(s) {
                         result += numer + ' over ' + denom + ' ';
                     }
                 } else {
-                    result += ' The fraction [[slnc 200]]' + numer + ', over [[slnc 150]]' + denom + '. End fraction.';
+                    result += ' The fraction [[slnc 200]]' + numer + ', over [[slnc 150]]' + denom + ', End fraction.';
                 }
 
                 break;
@@ -233,17 +233,17 @@ function emph(s) {
                     if (isAtomic(atom.body)) {
                         result += ' square root of ' + body + ' , ';
                     } else {
-                        result += ' The square root of ' + body + ' . End square root.';
+                        result += ' The square root of ' + body + ', End square root.';
                     }
                 } else {
                     let index = MathAtom.toSpeakableFragment(atom.index, options);
                     index = index.trim();
                     if (index === '3') {
-                        result += ' The cube root of ' + body + ' . End cube root.';
+                        result += ' The cube root of ' + body + ', End cube root.';
                     } else if (index === 'n') {
-                        result += ' The nth root of ' + body + ' . End root.';
+                        result += ' The nth root of ' + body + ', End root.';
                     } else {
-                        result += ' root with index: ' + index + ', of :' + body + ' . End root.';
+                        result += ' root with index: ' + index + ', of :' + body + ', End root.';
                     }
                 }
                 break;
@@ -374,7 +374,7 @@ function emph(s) {
                 if (isAtomic(atom.body)) {
                     result += ' crossed out ' + body + ' , ';
                 } else {
-                    result += ' crossed out ' + body + ' . End cross out.';
+                    result += ' crossed out ' + body + ' End cross out.';
                 }
                 break;
 
@@ -411,7 +411,7 @@ function emph(s) {
             if (isAtomic(atom.subscript)) {
                 result += ' sub ' + sub;
             } else {
-                result += ' subscript ' + sub + '. End subscript. ';
+                result += ' subscript ' + sub + ' End subscript. ';
             }
         }
         // If no markup was requested, remove any that we may have
@@ -450,8 +450,6 @@ version="1.0"><p><s xml:lang="en-US">`;
     }
 
     result += MathAtom.toSpeakableFragment(atoms, options);
-
-    result += '.';
 
     if (options.markup === 'ssml') {
         result += '</s></p></speak>';

--- a/src/editor/editor-shortcuts.js
+++ b/src/editor/editor-shortcuts.js
@@ -563,7 +563,7 @@ function matchEndOf(s, config) {
     if (customInlineShortcuts) {
         for (const k in customInlineShortcuts) {
             if (customInlineShortcuts.hasOwnProperty(k)) {
-                if (k.length >= matchLength && s.substr(-k.length) == k) {
+                if (k.length >= matchLength && s.substr(-k.length) === k) {
                     result = {
                         match: k,
                         substitute: customInlineShortcuts[k]

--- a/src/editor/editor-shortcuts.js
+++ b/src/editor/editor-shortcuts.js
@@ -563,7 +563,7 @@ function matchEndOf(s, config) {
     if (customInlineShortcuts) {
         for (const k in customInlineShortcuts) {
             if (customInlineShortcuts.hasOwnProperty(k)) {
-                if (k.length > matchLength && s.substr(-k.length) === k) {
+                if (k.length >= matchLength && s.substr(-k.length) == k) {
                     result = {
                         match: k,
                         substitute: customInlineShortcuts[k]

--- a/src/mathlive.js
+++ b/src/mathlive.js
@@ -335,6 +335,9 @@ function validateNamespace(options) {
 function revertToOriginalContent(element, options) {
     element = getElement(element);
     
+    // element is a pair: accessible span, math -- set it to the math part
+    element = element.children[1];
+
     if (element instanceof MathField.MathField) {
         element.revertToOriginalContent();
     } else {
@@ -359,6 +362,9 @@ function revertToOriginalContent(element, options) {
  */
 function getOriginalContent(element, options) {
     element = getElement(element);
+
+    // element is a pair: accessible span, math -- set it to the math part
+    element = element.children[1];
 
     if (element instanceof MathField.MathField) {
         return element.originalContent;


### PR DESCRIPTION
Correct logic for inlineShortcuts override. Fixes #23.

Big change (I think included in this) is the addition of code to make static math read with AT. I've tested it with NVDA. This change adds a span around the mathlive output. It uses aria-hidden on this span. It adds a sibling node that is the text to speak (should be MathML at some point in the future for better accessibility). This is visually hidden, but it is what screen readers see. Fixes #25.

I also tweaked the speech slightly based on NVDA speaking '.'s.