### PR TITLE
placeholder not showing up

### DIFF
--- a/src/core/lexer.js
+++ b/src/core/lexer.js
@@ -223,7 +223,7 @@ Lexer.prototype.makeToken = function() {
                 }
             }
             if (isParam) {
-                result = new Token('#');
+                result = new Token('placeholder');
                 next = this.get();
                 if (next >= '0' && next <= '9') {
                     result.value = parseInt(next);

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -1045,7 +1045,7 @@ Parser.prototype.scanArg = function(parseMode) {
 
     // If this is a param token, substitute it with the
     // (optional) argument passed to the parser
-    if (this.hasToken('#')) {
+    if (this.hasToken('placeholder')) {
         const paramToken = this.get();
         this.skipUntilToken('}');
         if (paramToken.value === '?') {
@@ -1140,10 +1140,6 @@ Parser.prototype.scanToken = function() {
         }
 
         result = new MathAtom(this.parseMode, 'command', body);
-
-    } else if (token.type === 'placeholder') {
-        // RENDER PLACEHOLDER
-        result = new MathAtom(this.parseMode, 'placeholder', token.value);
 
     } else if (token.type === 'command') {
         // RENDER COMMAND
@@ -1241,7 +1237,7 @@ Parser.prototype.scanToken = function() {
         }
         result.latex = Definitions.matchCodepoint(token.value);
 
-    } else if (token.type === '#') {
+    } else if (token.type === 'placeholder') {
         // Parameter token in an implicit group (not as a parameter)
         if (token.value === '?') {
             // U+2753 = BLACK QUESTION MARK ORNAMENT  
@@ -1254,6 +1250,9 @@ Parser.prototype.scanToken = function() {
                 const group = new MathAtom(this.parseMode, 'group');
                 group.children = result;
                 result = group;
+            } else {
+                // RENDER PLACEHOLDER (value is typically '0', so choose better value)
+                 result = new MathAtom(this.parseMode, 'placeholder', '\u2753'); // U+2753 = BLACK QUESTION MARK ORNAMENT);       
             }
         }
     } else {


### PR DESCRIPTION
There seemed to be some confusion between using type '#' and type'placeholder in the code. I switched everything to be 'placeholder'. That's mostly cosmetic.

The real fix is that in `Parser.prototype.scanToken`, there was one `if` testing for '#' (before the change above) and another testing for 'placeholder'. The fix was to move the 'placeholder' test into the '#' test so that when there was not something to replace, a placeholder was inserted into the result.

Note: the previous code in that case (which probably was never true) used
the value of the placeholder token (typically a '0') for the placeholder.
That's not great visually, so I switch to using 'U+2753 = BLACK QUESTION
MARK ORNAMENT' which was used elsewhere.

Now `alt-[` produces:  
![image](https://user-images.githubusercontent.com/1545836/32429185-5796fa4c-c27e-11e7-9f05-14d4f9b6d4d4.png)


Fixes #33.

