### PR TITLE
Fixed mathml not being in code tags.

### DIFF
--- a/docs/tutorial-MASTON.html
+++ b/docs/tutorial-MASTON.html
@@ -137,7 +137,7 @@ entity references or by composing them from base letters and style markup.</p>
 <li><code>comment</code>: A human readable string to annotate an expression, since JSON does not allow comments in its encoding</li>
 <li><code>error</code>: A human readable string that can be used to indicate a syntax error or other problem when parsing or evaluating an expression.</li>
 <li><code>latex</code>: A visual representation in LaTeX of the expression. This can be useful to preserve non-semantic details, for example parentheses in an expression.</li>
-<li>`mathml': A visual representation in MathML of the expression.</li>
+<li><code>mathml</code>: A visual representation in MathML of the expression.</li>
 <li><code>class</code>: A CSS class to be associated with a representation of this element</li>
 <li><code>id</code>: A CSS id to be associated with a representation of this element</li>
 <li><code>style</code>: A CSS style string</li>


### PR DESCRIPTION
`mathml` was listed as \`mathml\' and as a result did not appear in `code` tags, unlike the rest of the optional keys listed in the MASTON docs.