### PR TITLE
Fix minor docs typos

### DIFF
--- a/docs/addons_maston.js.html
+++ b/docs/addons_maston.js.html
@@ -1236,7 +1236,7 @@ function parsePrimary(expr, options) {
 }
 
 /**
- * Given an atom or an array of atoms, return their MathML representation as 
+ * Given an atom or an array of atoms, return their AST representation as 
  * a string.
  * @param {Object} expr An expressions, including expr.atoms, expr.index, 
  * expr.minPrec the minimum precedence that this parser should parse

--- a/docs/tutorial-CONTRIBUTOR_GUIDE.html
+++ b/docs/tutorial-CONTRIBUTOR_GUIDE.html
@@ -217,7 +217,7 @@ people who will read it later.</li>
 obscure constructs that may obfuscate the code to improve performance. For 
 example, RegEx are crazy fast in all modern browsers, and trying to roll out
 your own pattern matching will result in more code and less performance. 
-If you think something could be made faster, use [jsperf.com]<code>https://jsperf.com</code> to 
+If you think something could be made faster, use <a href="https://jsperf.com">jsperf.com</a> to 
 try out options in various browsers and compare the results. You might be 
 surprised.</li>
 <li><strong>Follow Postel's Law, the Robustness Principle</strong> &quot;Be conservative in what

--- a/docs/tutorial-USAGE_GUIDE.html
+++ b/docs/tutorial-USAGE_GUIDE.html
@@ -117,7 +117,7 @@ will be rendered as math:</p>
 </ul>
 <pre class="prettyprint source lang-html"><code>&lt;h1>Taxicab Number&lt;/h1>
 &lt;p>The second taxicab number is $$1729 = 10^3 + 9^3 = 12^3 + 1^3$$&lt;/p></code></pre><p>You can also wrap more complex expressions in a <code>&lt;script&gt;</code> tag with a type 
-of <code>math/tex</code>. This is the recommended approach for stand-along formulas. One 
+of <code>math/tex</code>. This is the recommended approach for stand-alone formulas. One 
 of the benefits of this approach is that the browser will not attempt to 
 display the content of the <code>&lt;script&gt;</code> tag before it is typeset, avoiding an 
 unsightly flash of LaTeX code on screen. If the type is <code>&quot;math/tex; mode=text&quot;</code> 

--- a/src/addons/maston.js
+++ b/src/addons/maston.js
@@ -1167,7 +1167,7 @@ function parsePrimary(expr, options) {
 
 /**
  * Given an atom or an array of atoms, return their AST representation as 
- * a string.
+ * an object.
  * @param {Object} expr An expressions, including expr.atoms, expr.index, 
  * expr.minPrec the minimum precedence that this parser should parse
  * before returning; expr.lhs (optional); expr.ast, the resulting AST.

--- a/src/addons/maston.js
+++ b/src/addons/maston.js
@@ -1166,7 +1166,7 @@ function parsePrimary(expr, options) {
 }
 
 /**
- * Given an atom or an array of atoms, return their MathML representation as 
+ * Given an atom or an array of atoms, return their AST representation as 
  * a string.
  * @param {Object} expr An expressions, including expr.atoms, expr.index, 
  * expr.minPrec the minimum precedence that this parser should parse

--- a/tutorials/CONTRIBUTOR_GUIDE.md
+++ b/tutorials/CONTRIBUTOR_GUIDE.md
@@ -173,7 +173,7 @@ people who will read it later.
 obscure constructs that may obfuscate the code to improve performance. For 
 example, RegEx are crazy fast in all modern browsers, and trying to roll out
 your own pattern matching will result in more code and less performance. 
-If you think something could be made faster, use [jsperf.com]`https://jsperf.com` to 
+If you think something could be made faster, use [jsperf.com](https://jsperf.com) to 
 try out options in various browsers and compare the results. You might be 
 surprised.
 * **Follow Postel's Law, the Robustness Principle** "Be conservative in what

--- a/tutorials/USAGE_GUIDE.md
+++ b/tutorials/USAGE_GUIDE.md
@@ -80,7 +80,7 @@ will be rendered as math:
 ```
 
 You can also wrap more complex expressions in a `<script>` tag with a type 
-of `math/tex`. This is the recommended approach for stand-along formulas. One 
+of `math/tex`. This is the recommended approach for stand-alone formulas. One 
 of the benefits of this approach is that the browser will not attempt to 
 display the content of the `<script>` tag before it is typeset, avoiding an 
 unsightly flash of LaTeX code on screen. If the type is `"math/tex; mode=text"` 


### PR DESCRIPTION
Fixed some minor typos/issues in the documentation:

- jsperf.com has a URL listed but no functioning link.
- stand-alone expressions described as 'stand-along'
- MASTON parseExpression claiming to return a MathML string, when it actually returns an AST object.