### PR TITLE
Add function docs

### DIFF
--- a/docs/mathlive.js.html
+++ b/docs/mathlive.js.html
@@ -366,7 +366,10 @@ function toSpeakableText() {
 }
 
 /**
- * @param {string} latex
+ * Convert a LaTeX string to a string of MathML markup.
+ * 
+ * @param {string} latex A string of valid LaTeX. It does not have to start
+ * with a mode token such as a `$$` or `\(`.
  * @return {string}
  * @function module:mathlive#latexToMathML
  */

--- a/docs/mathlive.js.html
+++ b/docs/mathlive.js.html
@@ -385,8 +385,14 @@ function toMathML(latex, options) {
 }
 
 /**
- * @param {string} latex
- * @return {string}
+ * Convert a LaTeX string to an Abstract Syntax Tree
+ * 
+ * **See:** {@tutorial MASTON}
+ * 
+ * @param {string} latex A string of valid LaTeX. It does not have to start
+ * with a mode token such as a `$$` or `\(`.
+ * 
+ * @return {Object} The Abstract Syntax Tree as a JavaScript object.
  * @function module:mathlive#latexToAST
  */
 function latexToAST(latex, options) {

--- a/docs/module-mathlive.html
+++ b/docs/module-mathlive.html
@@ -298,7 +298,7 @@ with a mode token such as a <code>$$</code> or <code>\(</code>.</p>
 
     
         <span class="tag-source">
-        <a href="mathlive.js.html#line317">Source</a>
+        <a href="mathlive.js.html#line320">Source</a>
         </span>
     
 
@@ -554,6 +554,10 @@ used to construct the markup. Valid values include <code>'mathlist'</code> and <
 
 
 
+<div class="description">
+    <p>Convert a LaTeX string to a string of MathML markup.</p>
+</div>
+
 
 
 
@@ -587,6 +591,12 @@ used to construct the markup. Valid values include <code>'mathlist'</code> and <
 
             
 
+            
+                    <p class="description last">
+                        <p>A string of valid LaTeX. It does not have to start
+with a mode token such as a <code>$$</code> or <code>\(</code>.</p>
+                    </p>
+                    
             
         </div>
 
@@ -2272,7 +2282,7 @@ for details</p>
 
     
         <span class="tag-source">
-        <a href="mathlive.js.html#line343">Source</a>
+        <a href="mathlive.js.html#line346">Source</a>
         </span>
     
 
@@ -2763,7 +2773,7 @@ of delimiters that will trigger a render of the content in 'textstyle' or
 
     
         <span class="tag-source">
-        <a href="mathlive.js.html#line380">Source</a>
+        <a href="mathlive.js.html#line383">Source</a>
         </span>
     
 
@@ -2955,7 +2965,7 @@ use the same namespace here.</p>
 
     
         <span class="tag-source">
-        <a href="mathlive.js.html#line437">Source</a>
+        <a href="mathlive.js.html#line440">Source</a>
         </span>
     
 
@@ -3167,7 +3177,7 @@ use the same namespace here.</p>
 
     
         <span class="tag-source">
-        <a href="mathlive.js.html#line464">Source</a>
+        <a href="mathlive.js.html#line467">Source</a>
         </span>
     
 

--- a/docs/module-mathlive.html
+++ b/docs/module-mathlive.html
@@ -187,11 +187,16 @@ public API.</p>
 
     
 
-    <h4 class="name" id="latexToAST">latexToAST<span class="signature">(latex<span class="signature-type">: string</span>)</span><span class="type-signature"> &rarr;  string</span><span class="type-signature"></span></h4>
+    <h4 class="name" id="latexToAST">latexToAST<span class="signature">(latex<span class="signature-type">: string</span>)</span><span class="type-signature"> &rarr;  Object</span><span class="type-signature"></span></h4>
 
     
 
 
+
+<div class="description">
+    <p>Convert a LaTeX string to an Abstract Syntax Tree</p>
+<p><strong>See:</strong> <a href="tutorial-MASTON.html">MASTON</a></p>
+</div>
 
 
 
@@ -227,6 +232,12 @@ public API.</p>
             
 
             
+                    <p class="description last">
+                        <p>A string of valid LaTeX. It does not have to start
+with a mode token such as a <code>$$</code> or <code>\(</code>.</p>
+                    </p>
+                    
+            
         </div>
 
     
@@ -242,11 +253,13 @@ public API.</p>
 <span class="param-desc">
     
         
-<span class="param-type">string</span>
+<span class="param-type">Object</span>
 
 
         &nbsp;&nbsp;
     
+    
+        <p>The Abstract Syntax Tree as a JavaScript object.</p>
     
 </span>
 
@@ -2259,7 +2272,7 @@ for details</p>
 
     
         <span class="tag-source">
-        <a href="mathlive.js.html#line337">Source</a>
+        <a href="mathlive.js.html#line343">Source</a>
         </span>
     
 
@@ -2750,7 +2763,7 @@ of delimiters that will trigger a render of the content in 'textstyle' or
 
     
         <span class="tag-source">
-        <a href="mathlive.js.html#line374">Source</a>
+        <a href="mathlive.js.html#line380">Source</a>
         </span>
     
 
@@ -2942,7 +2955,7 @@ use the same namespace here.</p>
 
     
         <span class="tag-source">
-        <a href="mathlive.js.html#line431">Source</a>
+        <a href="mathlive.js.html#line437">Source</a>
         </span>
     
 
@@ -3154,7 +3167,7 @@ use the same namespace here.</p>
 
     
         <span class="tag-source">
-        <a href="mathlive.js.html#line458">Source</a>
+        <a href="mathlive.js.html#line464">Source</a>
         </span>
     
 

--- a/src/mathlive.js
+++ b/src/mathlive.js
@@ -315,8 +315,14 @@ function toMathML(latex, options) {
 }
 
 /**
- * @param {string} latex
- * @return {string}
+ * Convert a LaTeX string to an Abstract Syntax Tree
+ * 
+ * **See:** {@tutorial MASTON}
+ * 
+ * @param {string} latex A string of valid LaTeX. It does not have to start
+ * with a mode token such as a `$$` or `\(`.
+ * 
+ * @return {Object} The Abstract Syntax Tree as a JavaScript object.
  * @function module:mathlive#latexToAST
  */
 function latexToAST(latex, options) {

--- a/src/mathlive.js
+++ b/src/mathlive.js
@@ -296,7 +296,10 @@ function toSpeakableText() {
 }
 
 /**
- * @param {string} latex
+ * Convert a LaTeX string to a string of MathML markup.
+ * 
+ * @param {string} latex A string of valid LaTeX. It does not have to start
+ * with a mode token such as a `$$` or `\(`.
  * @return {string}
  * @function module:mathlive#latexToMathML
  */


### PR DESCRIPTION
Added documentation for the `latexToAST` and `latexToMathML` functions.

This is assuming that the intended return type for `latexToAST` is in fact `Object` (its current return type) and not `string` as the docs previously stated.