### PR TITLE
Correct fix involving selection (https://github.com/arnog/mathlive/co…

### DIFF
--- a/src/editor/editor-editableMathlist.js
+++ b/src/editor/editor-editableMathlist.js
@@ -623,8 +623,8 @@ EditableMathlist.prototype.extractContents = function() {
     const firstOffset = this.startOffset();
     if (firstOffset < siblings.length) {
         // const lastOffset = Math.min(siblings.length, this.endOffset());
-        const endOffset = Math.min(siblings.length - 1, this.endOffset());
-        for (let i = firstOffset; i <= endOffset; i++) {
+        const endOffset = Math.min(siblings.length, this.endOffset());
+        for (let i = firstOffset; i < endOffset; i++) {
             result.push(siblings[i]);
         }
     }


### PR DESCRIPTION
…mmit/db11903aaa69de51e917f6bf7d79dc1e6fa688fa#diff-f77fb358d14d9dc30247a7cdc3361bf7). That fix resulted in an extra char being part of the selection for most cases (those not involving the last char).

I believe not subtracting '1' from the length of the list when doing a max is the proper fix. It seems that this line (`max(...)`) is there to avoid a case where the `endoffset()` exceeds the length of the sibling list. I presume that only happens if there is an error in the code so this is just protection.