### PR TITLE
Revert crossout

### DIFF
--- a/src/addons/outputSpokenText.js
+++ b/src/addons/outputSpokenText.js
@@ -224,6 +224,7 @@ MathAtom.toSpeakableFragment = function(atom, options) {
     }
 
     if (Array.isArray(atom)) {
+        let isInDigitRun = false;             // need to group sequence of digits
         for (let i = 0; i < atom.length; i++) {
             if (i < atom.length - 2 &&  
                 atom[i].type === 'mopen' && 
@@ -232,7 +233,17 @@ MathAtom.toSpeakableFragment = function(atom, options) {
                 result += ' of ';
                 result += emph(MathAtom.toSpeakableFragment(atom[i + 1], options));
                 i += 2;
+            // '.' and ',' should only be allowed if prev/next entry is a digit
+            // However, if that isn't the case, this still works because 'toSpeakableFragment' is called in either case.
+            } else if (atom[i].type === 'mord' && /[0123456789,.]/.test(atom[i].latex)) {
+                if (isInDigitRun) {
+                    result += atom[i].latex;
+                } else {
+                    isInDigitRun = true;
+                    result += MathAtom.toSpeakableFragment(atom[i], options);
+                }
             } else {
+                isInDigitRun = false
                 result += MathAtom.toSpeakableFragment(atom[i], options);
             }
         }

--- a/src/core/mathAtom.js
+++ b/src/core/mathAtom.js
@@ -1169,7 +1169,7 @@ MathAtom.prototype.decomposeEnclose = function(context) {
     const padding = this.padding === 'auto' ? .2 : this.padding; // em
     result.setStyle('padding', padding, 'em');
 
-    result.setStyle('display', 'inline-block');
+    // result.setStyle('display', 'inline-block');
     // result.setStyle('position', 'relative');
     result.setStyle('height', result.height + result.depth , 'em');
     result.setStyle('left', -padding , 'em');


### PR DESCRIPTION
Removed
   display: inline-block
This causes the crossout to be positioned in the wrong place. Fixes #78.
Unfortunately, the size also changes back to the old bad size shown in #26.
Note that the sizing for #63 remains fixed.

Hence, this is two steps forward, one step back. If you accept this fix, then re-open #26. 