### PR TITLE
added missed JSON property's mapping.

### DIFF
--- a/examples/virtual_keyboard/index.html
+++ b/examples/virtual_keyboard/index.html
@@ -74,8 +74,9 @@
                                 "class": "keycap btn",
                                 "insert": "",
                                 "key": "",
+                                "latex": "\\frac{x}{(9)}",
                                 "command": "",
-                                "label": "7"
+                                "label": ""
                             },
                             {
                                 "class": "keycap btn",
@@ -93,7 +94,7 @@
                             },
                             {
                                 "class": "keycap",
-                                "dataInsert": "\\frac{#0}{#?}",
+                                "insert": "\\frac{#0}{#?}",
                                 "command": "",
                                 "label": "&divide;"
                             },
@@ -136,7 +137,7 @@
                             },
                             {
                                 "class": "keycap",
-                                "dataInsert": "\\times ",
+                                "insert": "\\times ",
                                 "command": "",
                                 "label": "&times;"
                             },

--- a/src/editor/editor-virtualKeyboard.js
+++ b/src/editor/editor-virtualKeyboard.js
@@ -1207,12 +1207,34 @@ function make(mf, theme) {
                             if (col.key) {
                                 tempLayer += ` data-key="${col.key}"`;
                             }
+
                             if (col.command) {
                                 tempLayer += ` data-command='"${col.command}"'`;
                             }
                             if (col.insert) {
                                 tempLayer += ` data-insert="${col.insert}"`;
                             }
+
+                            if (col.latex) {
+                                tempLayer += ` data-latex="${col.latex}"`;
+                            }
+
+                            if (col.aside) {
+                                tempLayer += ` data-aside="${col.aside}"`;
+                            }
+
+                            if (col.altKeys) {
+                                tempLayer += ` data-alt-keys="${col.altKeys}"`;
+                            }
+
+                            if (col.shifted) {
+                                tempLayer += ` data-shifted="${col.shifted}"`;
+                            }
+
+                            if (col.shiftedCommand) {
+                                tempLayer += ` data-shifted-command="${col.shiftedCommand}"`;
+                            }
+
                             tempLayer += `>${col.label ? col.label : ''}</li>`;
                         }
                         tempLayer += `</ul>`;


### PR DESCRIPTION
**lisp-case** props are represented by **camelCase** in JSON
New JSON example:
```
{
    "class": "",
    "insert": "",
    "key": "",
    "latex": "",
    "aside": "",
    "altKeys": "",
    "shifted": "",
    "shiftedCommand": "",
    "command": "",
    "label": ""
}
```