### PR TITLE
Reducing node required version to LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "engines": {
     "npm": ">=6.7",
-    "node": ">=11.9"
+    "node": ">=10.0"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
A recent update to the package made it fail to install because the engine for Node became specified as the latest Node major version. This PR just changes that requirement to allow the 10.x LTS versions as that's what we are using and can't see anything in Mathlive that would require the latest version of Node. 

We were maintaining an entire fork just for this change but it makes it much harder for us to take updates, so it'd be great if the main package could reduce the required Node version a little bit.