### PR TITLE
Spoken ssml with highlighting

### DIFF
--- a/examples/speech/index.html
+++ b/examples/speech/index.html
@@ -173,7 +173,9 @@
 
         <div class="mathfield" id='mf' >x=\frac{-b\pm\sqrt{b^2-4ac}}{2a}</div>
         <div id='output'>
+            <h3>Spoken Text</h3>
             <div id='output-text'></div>
+            <h3>SSML version of Spoken Text</h3>
             <div id='output-ssml'></div>
         </div>
         <!-- <div class='toolbar'>
@@ -239,13 +241,13 @@
 
 
 <script type='module'> 
-import MathLive from '/dist/mathlive.mjs';
+import MathLive from '/dist/mathlive.js';
 window.MathLive = MathLive;
 MathLive.renderMathInDocument({ignoreClass: "mathfield"});
 
 document.getElementById('start-button').addEventListener('click', () => {
     try {
-        mf.$perform("speakAllWithSynchronizedHighlighting")
+        mf.$perform(["speak", "all", {withHighlighting: true}])
     } catch (e) {
         console.log(e);
     }
@@ -257,6 +259,7 @@ document.getElementById('speed-slider').addEventListener('input', function() {
 });
 
 const mf = MathLive.makeMathField('mf', {
+    speechEngine: 'amazon',
     onContentDidChange: mf => {
         document.getElementById('output-text').textContent = mf.$text('spoken-text');
         document.getElementById('output-ssml').textContent = mf.$text('spoken-ssml');
@@ -297,7 +300,7 @@ setSpeed(3);
 function pauseResume() {
     try {
         if (!window.mathlive) {
-            mf.$perform("speakAllWithSynchronizedHighlighting");
+            mf.$perform(["speak", "all", {withHighlighting: true}]);
             return;
         }
 
@@ -318,7 +321,7 @@ function pauseResume() {
 
 function repeat(count) {
     if (!window.mathlive) {
-        mf.$perform("speakAllWithSynchronizedHighlighting");
+        mf.$perform(["speak", "all", {withHighlighting: true}]);
         return;
     }
     count = count || 1;

--- a/examples/speech/index.js
+++ b/examples/speech/index.js
@@ -58,7 +58,7 @@ function select_text_in_element(element) {
 
 
 function speak_all() {
-    mf.$perform("speakAllWithSynchronizedHighlighting");
+    mf.$perform(["speak", "all", {withHighlighting: true}]);
 }
 
 function speak_pause_resume() {

--- a/examples/vue/index.html
+++ b/examples/vue/index.html
@@ -28,7 +28,7 @@
         }},
         methods: {
             sayIt: function(event) {
-                this.$refs.mathfield.perform('speakAll');
+                this.$refs.mathfield.perform(['speak', 'all');
             },
             setIt: function(event) {
                 this.formula = 'x=-b\\pm \\frac {\\sqrt{b^2-4ac}}{2a}';

--- a/src/addons/outputSpokenText.js
+++ b/src/addons/outputSpokenText.js
@@ -34,7 +34,8 @@ const PRONUNCIATION = {
     '\\sum':        'Summation ',
     '\\prod':       'Product ',
 
-
+    'a':            '<phoneme alphabet="ipa" ph="eɪ">a</phoneme>',
+    'A':            'capital <phoneme alphabet="ipa" ph="eɪ">A</phoneme>',
     '+':            'plus ',
     '-':            'minus ',
     ';':            '<break time="150ms"/> semi-colon <break time="150ms"/>',

--- a/src/editor/editor-mathfield.js
+++ b/src/editor/editor-mathfield.js
@@ -2045,9 +2045,12 @@ MathField.prototype.formatMathlist = function(root, format) {
         result = MathAtom.toSpeakableText(root, this.config);
         this.config.textToSpeechMarkup = save;
 
-    } else if (format === 'spoken-ssml') {
+    } else if (format === 'spoken-ssml' ||  format === 'spoken-ssml-withHighlighting') {
         const save = this.config.textToSpeechMarkup;
         this.config.textToSpeechMarkup = 'ssml';
+        if (format === 'spoken-ssml-withHighlighting') {
+            this.config.generateID = true;
+        }
         result = MathAtom.toSpeakableText(root, this.config);
         this.config.textToSpeechMarkup = save;
 
@@ -2080,7 +2083,8 @@ MathField.prototype.formatMathlist = function(root, format) {
  *    * `'spoken'`
  *    * `'spoken-text'`
  *    * `'spoken-ssml'`
- *    * `'mathML'`
+  *    * `spoken-ssml-withHighlighting`
+*    * `'mathML'`
  *    * `'json'`
  * @return {string}
  * @method MathField#$text
@@ -2098,6 +2102,7 @@ MathField.prototype.$text = function(format) {
  *    * `'spoken'`
  *    * `'spoken-text'`
  *    * `'spoken-ssml'`
+ *    * `spoken-ssml-withHighlighting`
  *    * `'mathML'`
  *    * `'json'`
  * @return {string}
@@ -3540,7 +3545,7 @@ MathField.prototype.$setConfig = function(conf) {
  * 
  * @param {string} amount (all, selection, left, right, group, parent)
  * @param {object} speakOptions 
- * @param {boolean} speakOptions.withHighlighting - If true, synchronized highlighting of speech will happen (if possible)
+ * @param {boolean} speakOptions.withHighlighting - If true, synchronized highlighting of speech will happen (if possible). Default is false.
  * 
  * @method MathField#speak_
  */

--- a/src/editor/editor-mathfield.js
+++ b/src/editor/editor-mathfield.js
@@ -3636,8 +3636,11 @@ MathField.prototype.speak_ = function(amount, speakOptions) {
     }
 
     const options = this.config;
-    if (speakOptions.withHighlighting | options.speechEngine === 'amazon') {
+    if (speakOptions.withHighlighting || options.speechEngine === 'amazon') {
         options.textToSpeechMarkup = (window.sre && options.textToSpeechRules === 'sre') ? 'ssml_step' : 'ssml';
+        if (speakOptions.withHighlighting) {
+            options.generateID = true;
+        }
     }
     const text = MathAtom.toSpeakableText(atoms, options)
 

--- a/src/editor/editor-shortcuts.js
+++ b/src/editor/editor-shortcuts.js
@@ -230,8 +230,8 @@ const KEYBOARD_SHORTCUTS = {
 */
     'mac:Ctrl-Meta-Up':           ['speak', 'parent', {withHighlighting: false}],
     '!mac:Ctrl-Alt-Up':           ['speak', 'parent', {withHighlighting: false}],
-    'mac:Ctrl-Meta-Down':         ['speak', 'group', {withHighlighting: false}],
-    '!mac:Ctrl-Alt-Down':         ['speak', 'group', {withHighlighting: false}],
+    'mac:Ctrl-Meta-Down':         ['speak', 'all', {withHighlighting: false}],
+    '!mac:Ctrl-Alt-Down':         ['speak', 'all', {withHighlighting: false}],
     'mac:Ctrl-Meta-Left':         ['speak', 'left', {withHighlighting: false}],
     '!mac:Ctrl-Alt-Left':         ['speak', 'left', {withHighlighting: false}],
     'mac:Ctrl-Meta-Right':        ['speak', 'right', {withHighlighting: false}],
@@ -241,8 +241,8 @@ const KEYBOARD_SHORTCUTS = {
   
     'mac:Ctrl-Meta-Shift-Up':     ['speak', 'parent', {withHighlighting: true}],
     '!mac:Ctrl-Alt-Shift-Up':     ['speak', 'parent', {withHighlighting: true}],
-    'mac:Ctrl-Meta-Shift-Down':   ['speak', 'group', {withHighlighting: true}],
-    '!mac:Ctrl-Alt-Shift-Down':   ['speak', 'group', {withHighlighting: true}],
+    'mac:Ctrl-Meta-Shift-Down':   ['speak', 'all', {withHighlighting: true}],
+    '!mac:Ctrl-Alt-Shift-Down':   ['speak', 'all', {withHighlighting: true}],
     'mac:Ctrl-Meta-Shift-Left':   ['speak', 'left', {withHighlighting: true}],
     '!mac:Ctrl-Alt-Shift-Left':   ['speak', 'left', {withHighlighting: true}],
     'mac:Ctrl-Meta-Shift-Right':  ['speak', 'right', {withHighlighting: true}],

--- a/src/mathlive.js
+++ b/src/mathlive.js
@@ -495,7 +495,7 @@ function readAloud(element, text, config) {
  * - `paused`
  * - `unavailable`
  * 
- * **See** {@linkcode module:editor-mathfield#speakAllWithSynchronizedHighlighting speakAllWithSynchronizedHighlighting}
+ * **See** {@linkcode module:editor-mathfield#speak speak}
  * @return {string}
  * @function module:mathlive#readAloudStatus
  */
@@ -513,7 +513,7 @@ function readAloudStatus() {
 /**
  * If a Read Aloud operation is in progress, stop it.
  * 
- * **See** {@linkcode module:editor/mathfield#speakAllWithSynchronizedHighlighting speakAllWithSynchronizedHighlighting}
+ * **See** {@linkcode module:editor/mathfield#speak speak}
  * @function module:mathlive#pauseReadAloud
  */
 function pauseReadAloud() {
@@ -530,7 +530,7 @@ function pauseReadAloud() {
 /**
  * If a Read Aloud operation is paused, resume it
  * 
- * **See** {@linkcode module:editor-mathfield#speakAllWithSynchronizedHighlighting speakAllWithSynchronizedHighlighting}
+ * **See** {@linkcode module:editor-mathfield#speak speak}
  * @function module:mathlive#resumeReadAloud
  */
 function resumeReadAloud() {
@@ -547,7 +547,7 @@ function resumeReadAloud() {
 /**
  * If a Read Aloud operation is in progress, read from a specified token
  * 
- * **See** {@linkcode module:editor-mathfield#speakAllWithSynchronizedHighlighting speakAllWithSynchronizedHighlighting}
+ * **See** {@linkcode module:editor-mathfield#speak speak}
  *
  * @param {string} token
  * @param {number} [count]
@@ -672,7 +672,7 @@ function getElement(element) {
  *      elem.innerHTML = elem.dataset.originalContent;
  * ```
  * @param {boolean} [options.readAloud=false] if true, generate markup that can
- * be read aloud later using {@linkcode module:editor-mathfield#speakAllWithSynchronizedHighlighting speakAllWithSynchronizedHighlighting}
+ * be read aloud later using {@linkcode module:editor-mathfield#speak speak}
  * 
  * @param {boolean} [options.TeX.processEnvironments=true] if false, math expression
  * that start with `\begin{` will not automatically be rendered.

--- a/tutorials/SELECTORS.md
+++ b/tutorials/SELECTORS.md
@@ -108,11 +108,4 @@ The following selectors can be passed to [`MathField.$perform()`]{@link MathFiel
 
 | Name                 | Description               |
 | --------------------- | ------------------------- |
-| `speakSelection` | |
-| `speakParent` | |
-| `speakRightSibling` | |
-| `speakLeftSibling` | |
-| `speakGroup` | |
-| `speakAll` | |
-| `speakSelectionWithSynchronizedHighlighting` | |
-| `speakAllWithSynchronizedHighlighting` | |
+| `speak` | speaks the amount specified by the first parameter. |

--- a/tutorials/USAGE_GUIDE.md
+++ b/tutorials/USAGE_GUIDE.md
@@ -312,11 +312,14 @@ displays the keys being typed, including the shortcuts. Great for demos!
 * `addColumnAfter`, `addColumnBefore`
 
 ### Speech
-* `speakAll`
-* `speakSelection`
-* `speakParent`
-* `speakGroup`
-* `speakLeftSibling`, `speakRightSibling`
+* `speak` This selector takes two arguments. The first argument is a string that determines what should be spoken. The valid values are:
+  * `all`
+  * `left`
+  * `right`
+  * `selection`
+  * `parent`
+  * `group`
+The second parameter determines whether what is being spoken should be highlighted. It is an object: `{withHighlighting: boolean}` (default is false). Note: highlighting currently only works when connected to Amazon's AWS speech synthesizer.
 
 
 ## Virtual Keyboards


### PR DESCRIPTION
As per a conversation with Arno, added an option to $text and $selectedText so that one can see the markup when SSML is generated with text highlighting turned on ("read aloud" functionality).