### PR TITLE
Fix incorrect loop-condition

### DIFF
--- a/src/editor/editor-editableMathlist.js
+++ b/src/editor/editor-editableMathlist.js
@@ -2009,7 +2009,7 @@ EditableMathlist.prototype.simplifyParen = function(atoms) {
                     let genFracCount = 0;
                     let genFracIndex = 0;
                     let nonGenFracCount = 0;
-                    for (let j = 0; atoms[i].body; j++) {
+                    for (let j = 0; atoms[i].body[j]; j++) {
                         if (atoms[i].body[j].type === 'genfrac') {
                             genFracCount++;
                             genFracIndex = j;


### PR DESCRIPTION
This fixes an error I got when pasting `\frac{n\cdot \left(n+1\right)}{2}` into a mathfield with `removeExtraneousParentheses` active by default. 