### PR TITLE
Add types-info to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "/LICENSE.txt"
   ],
   "main": "./dist/mathlive.js",
+  "types": "./dist/types.d.ts",
   "scripts": {
     "preclean": "echo Clean directories...",
     "clean": "rimraf build dist docs",


### PR DESCRIPTION
Since the type-declaration-file has not the same name as the emitted js-file, Typescript is not automatically associating them with each other.