### PR TITLE
fix Popover position

### DIFF
--- a/css/mathlive.core.less
+++ b/css/mathlive.core.less
@@ -246,4 +246,11 @@ body[theme="dark"] .ML__fieldcontainer {
     }
 }
 
-
+.reverse-direction {
+    &::after {
+        top: auto;
+        bottom: -5px;
+        border-top: 5px solid rgba(97, 97, 97, .9);
+        border-bottom: 0;
+    }
+}

--- a/src/editor/editor-mathfield.js
+++ b/src/editor/editor-mathfield.js
@@ -562,10 +562,12 @@ class MathField {
         const caret = _findElementWithCaret(this.field);
         if (caret) {
             const bounds = caret.getBoundingClientRect();
-            return {
-                x: bounds.right + window.scrollX,
-                y: bounds.bottom + window.scrollY
+            const position = {
+                x: bounds.right,
+                y: bounds.bottom,
+                height: bounds.height,
             };
+            return position;
         }
         return null;
     }

--- a/src/editor/editor-popover.js
+++ b/src/editor/editor-popover.js
@@ -441,12 +441,7 @@ function updatePopoverPosition(mf, options) {
             } else {
                 // ... get the caret position
                 const position = mf._getCaretPosition();
-                if (position) {
-                    // and position the popover right below the caret
-                    mf.popover.style.left =
-                        (position.x - mf.popover.offsetWidth / 2) + 'px';
-                    mf.popover.style.top = (position.y + 5) + 'px';
-                }
+                if (position) setPopoverPosition(mf, position);
             }
         }
     }
@@ -456,14 +451,50 @@ function showPopover(mf, markup) {
     mf.popover.innerHTML = markup;
 
     const position = mf._getCaretPosition();
-    if (position) {
-        mf.popover.style.left = (position.x - mf.popover.offsetWidth / 2) + 'px';
-        mf.popover.style.top = (position.y + 5) + 'px';
-    }
+    if (position) setPopoverPosition(mf, position);
 
     mf.popover.classList.add('is-visible');
 }
 
+function setPopoverPosition(mf, position) {
+    // get screen width & height (browser compatibility)
+    const screen_height = window.innerHeight ||
+        document.documentElement.clientHeight ||
+        document.body.clientHeight;
+    const screen_width = window.innerWidth ||
+        document.documentElement.clientWidth ||
+        document.body.clientWidth;
+
+    // get scrollbar size. This would be 0 in mobile device (also no needed).
+    const scrollbar_width = window.innerWidth -
+        document.documentElement.clientWidth;
+    const scrollbar_height = window.innerHeight -
+        document.documentElement.clientHeight;
+    const virtualkeyboard_height = mf.virtualKeyboardVisible ?
+        mf.virtualKeyboard.offsetHeight : 0;
+    // prevent screen overflow horizontal.
+    if (position.x + (mf.popover.offsetWidth / 2) > screen_width - scrollbar_width) {
+        mf.popover.style.left =
+            (screen_width - mf.popover.offsetWidth - scrollbar_width) + 'px';
+    } else if (position.x - (mf.popover.offsetWidth / 2) < 0) {
+        mf.popover.style.left = 0;
+    } else {
+        mf.popover.style.left =
+            (position.x - mf.popover.offsetWidth / 2) + 'px';
+    }
+
+    // and position the popover right below or above the caret
+    if (position.y + mf.popover.offsetHeight + 5 > 
+        screen_height - scrollbar_height - virtualkeyboard_height) {
+        mf.popover.classList.add('reverse-direction');
+        mf.popover.style.top = 
+            (position.y - position.height - 
+            mf.popover.offsetHeight - 5) + 'px';
+    } else {
+        mf.popover.classList.remove('reverse-direction');
+        mf.popover.style.top = (position.y + 5) + 'px';
+    }
+}
 
 function hidePopover(mf) {
     mf.popover.classList.remove('is-visible');


### PR DESCRIPTION
relevant to #229 .

Fixed the bug that wrong popover y position when user scroll down.

Set popover position relative to browser's screen size.  When current height of popover is not sufficient to render bottom, render it above the caret position. 
Prevent appearing popover out of screen. Also considered with virtual keyboard size to prevent appearing below the virtual keyboard.
