### PR TITLE
make all links to fonts depend on the @font-folder variable

### DIFF
--- a/css/mathlive.less
+++ b/css/mathlive.less
@@ -2,8 +2,8 @@
 
 @font-face {
     font-family: KaTeX_Main;
-    src: url(fonts/KaTeX_Main-Regular.woff2) format('woff2'),
-        url(fonts/KaTeX_Main-Regular.woff) format('woff');
+    src: url('@{font-folder}/KaTeX_Main-Regular.woff2') format('woff2'),
+        url('@{font-folder}/KaTeX_Main-Regular.woff') format('woff');
     font-weight: 400;
     font-style: normal;
     font-display: 'swap';
@@ -11,8 +11,8 @@
 
 @font-face {
     font-family: KaTeX_Math;
-    src: url(fonts/KaTeX_Math-Italic.woff2) format('woff2'),
-        url(fonts/KaTeX_Math-Italic.woff) format('woff');
+    src: url('@{font-folder}/KaTeX_Math-Italic.woff2') format('woff2'),
+        url('@{font-folder}/KaTeX_Math-Italic.woff') format('woff');
     font-weight: 400;
     font-style: italic;
     font-display: 'swap';


### PR DESCRIPTION
Hi, I needed to change the font folder to create a plugin for the discourse.org forum software. the @font-folder variable was hard coded in one place. Maybe this is of help to others in a similar situation.
Thaaaanks 
spirobel 