### PR TITLE
Fix focus bug on iOS 12 and Firefox/Android

### DIFF
--- a/src/editor/mathfield-pointer-input.ts
+++ b/src/editor/mathfield-pointer-input.ts
@@ -20,7 +20,7 @@ export function onPointerDown(mathfield: MathfieldPrivate, evt) {
     let trackingWords = false;
     let dirty = false;
     // If a mouse button other than the main one was pressed, return
-    if (evt.buttons !== 1) {
+    if (evt.buttons !== 1 && evt.buttons !== 0) {
         return;
     }
     let scrollLeft = false;


### PR DESCRIPTION
(and maybe others?)

Test plan:
- Visit /examples/basic/index.esm.html on an iPhone 6
- Tap into mathfield; it gets focus
- Tap around mathfield to move cursor