### PR TITLE
Fix broken typescript definitions path

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     },
     "main": "./dist/mathlive.js",
     "module": "./dist/mathlive.mjs",
-    "types": "./dist/mathlive.d.ts",
+    "types": "./dist/public/mathlive.d.ts",
     "files": [
         "/dist"
     ],


### PR DESCRIPTION
After moving typescript definitions to public folder, typescript was unable to find type definitions. This fixes that.

@arnog If we had an e2e test for this, it would've been detected earlier.

Thanks for your efforts 👍 