### PR TITLE
fix: Add more ways to move out of mathfield #591

### DIFF
--- a/src/editor/model-selection.ts
+++ b/src/editor/model-selection.ts
@@ -635,6 +635,9 @@ export function up(
         }
     } else {
         model.announce('line');
+        if (!model.suppressChangeNotifications) {
+            model.hooks?.moveOut(model, 'upward');
+        }
     }
     return true;
 }
@@ -675,6 +678,9 @@ export function down(
         }
     } else {
         model.announce('line');
+        if (!model.suppressChangeNotifications) {
+            model.hooks?.moveOut(model, 'downward');
+        }
     }
     return true;
 }

--- a/src/editor/model-selection.ts
+++ b/src/editor/model-selection.ts
@@ -635,8 +635,11 @@ export function up(
         }
     } else {
         model.announce('line');
-        if (!model.suppressChangeNotifications) {
-            model.hooks?.moveOut(model, 'upward');
+        if (
+            !model.suppressChangeNotifications &&
+            !model.hooks?.moveOut(model, 'upward')
+        ) {
+            return false;
         }
     }
     return true;
@@ -678,8 +681,11 @@ export function down(
         }
     } else {
         model.announce('line');
-        if (!model.suppressChangeNotifications) {
-            model.hooks?.moveOut(model, 'downward');
+        if (
+            !model.suppressChangeNotifications &&
+            !model.hooks?.moveOut(model, 'downward')
+        ) {
+            return false;
         }
     }
     return true;

--- a/src/editor/model-utils.ts
+++ b/src/editor/model-utils.ts
@@ -31,7 +31,7 @@ export type ModelHooks = {
     ) => void;
     moveOut?: (
         sender: ModelPrivate,
-        direction: 'forward' | 'backward'
+        direction: 'forward' | 'backward' | 'upward' | 'downward'
     ) => boolean;
     tabOut?: (
         sender: ModelPrivate,

--- a/src/public/config.ts
+++ b/src/public/config.ts
@@ -382,7 +382,7 @@ export interface MathfieldHooks {
      * point to leave the mathfield.
      *
      * - <var>direction</var> indicates the direction of the navigation, either
-     * `"forward"` or `"backward"`.
+     * `"forward"` or `"backward"` or `"upward"` or `"downward"`.
      *
      * Return `false` to prevent the move, `true` to wrap around to the
      * start of the field.
@@ -391,7 +391,7 @@ export interface MathfieldHooks {
      */
     onMoveOutOf?: (
         sender: Mathfield,
-        direction: 'forward' | 'backward'
+        direction: 'forward' | 'backward' | 'upward' | 'downward'
     ) => boolean;
     /**
      * A hook invoked when pressing tab (or shift-tab) would cause the


### PR DESCRIPTION
Fixes #591

However, this doesn't add wrapping around for `upward`s and `downward`s movement. 