### PR TITLE
fix: Don't throw an error when the first argument of \enclose is empty

### DIFF
--- a/src/core/definitions-enclose.ts
+++ b/src/core/definitions-enclose.ts
@@ -73,7 +73,7 @@ defineFunction(
 
         // Normalize the list of notations.
         result.notation = {};
-        (args[0] as string)
+        (args[0] as string ?? '')
             .split(/[, ]/)
             .filter((v) => v.length > 0)
             .forEach((x) => {


### PR DESCRIPTION
Previously, the first argument could be an empty array `[]`. Actually, maybe that's a bug with the argument parsing function?

