### PR TITLE
Fix issue when typing "sqrt"

### DIFF
--- a/src/editor/shortcuts-definitions.ts
+++ b/src/editor/shortcuts-definitions.ts
@@ -56,7 +56,7 @@ export const INLINE_SHORTCUTS: {
     '∑': { mode: 'math', value: '\\sum' },
     sum: { mode: 'math', value: '\\sum_{#?}^{#?}' },
     prod: { mode: 'math', value: '\\prod_{#?}^{#?}' },
-    sqrt: { mode: 'math', value: '\\sqrt' },
+    sqrt: { mode: 'math', value: '\\sqrt{#?}' },
     // '∫':                    '\\int',             // There's a alt-B command for this
     '∆': { mode: 'math', value: '\\differentialD' }, // @TODO: is \\diffD most common?
     '∂': { mode: 'math', value: '\\differentialD' },


### PR DESCRIPTION
Previously, typing "sqrt2" would insert "\sqrt[]{}2". With this change, typing "sqrt2" will insert "\sqrt[]{2}".