### PR TITLE
Improve getConfig typings

### DIFF
--- a/src/public/mathfield.ts
+++ b/src/public/mathfield.ts
@@ -82,7 +82,7 @@ export type InsertOptions = {
 export interface Mathfield {
     mode: ParseMode;
 
-    getConfig(keys: keyof MathfieldConfig): any;
+    getConfig<T extends keyof MathfieldConfig>(key: T): MathfieldConfig[T];
     getConfig(keys: string[]): MathfieldConfig;
     getConfig(keys: keyof MathfieldConfig | string[]): any | MathfieldConfig;
 


### PR DESCRIPTION
This improves the public `getConfig()` type for the single key case. 
e.g. `mathfield.value.getConfig("keybindings")` will now return a `Keybinding[]`.

@ arnog 
If you want, I can also change the internal `getConfig` methods to use these typings. Also, if it would be useful, I can try to create a fully typesafe version of `getConfig(keys: string[]): MathfieldConfig;` Regarding the types, why does the last overload exist? Furthermore, why is `getConfig` the only method that doesn't have a `$`?

Furthermore, while I'm at it, if there are any other bits and bobs that could use some extra type safety, I'd be more than happy to take a look at them!
