### PR TITLE
Improve getConfig and selector types

### DIFF
--- a/src/editor/commands.ts
+++ b/src/editor/commands.ts
@@ -52,7 +52,7 @@ export function register(
 
 export function perform(
     mathfield: MathfieldPrivate,
-    command: SelectorPrivate | any[]
+    command: SelectorPrivate | [SelectorPrivate, ...any[]]
 ): boolean {
     if (!command) {
         return false;

--- a/src/editor/keybindings.ts
+++ b/src/editor/keybindings.ts
@@ -53,7 +53,7 @@ export function getCommandForKeybinding(
     keybindings: Keybinding[],
     mode: ParseMode,
     keystroke: string
-): Selector | any[] | '' {
+): Selector | [Selector, ...any[]] | '' {
     if (keybindings.length === 0) return '';
 
     // Try to match using a virtual keystroke

--- a/src/editor/mathfield-class.ts
+++ b/src/editor/mathfield-class.ts
@@ -659,7 +659,7 @@ export class MathfieldPrivate implements Mathfield {
         updatePopoverPosition(this);
     }
 
-    $perform(command: SelectorPrivate | any[]): boolean {
+    $perform(command: SelectorPrivate | [SelectorPrivate, ...any[]]): boolean {
         return perform(this, command);
     }
 

--- a/src/editor/mathfield-class.ts
+++ b/src/editor/mathfield-class.ts
@@ -469,11 +469,16 @@ export class MathfieldPrivate implements Mathfield {
         requestUpdate(this);
     }
 
-    getConfig(keys: keyof MathfieldConfigPrivate): boolean | number | string;
-    getConfig(keys: string[]): MathfieldConfigPrivate;
+    getConfig<K extends keyof MathfieldConfigPrivate>(
+        keys: K[]
+    ): Pick<MathfieldConfigPrivate, K>;
+    getConfig<K extends keyof MathfieldConfigPrivate>(
+        key: K
+    ): MathfieldConfigPrivate[K];
+    getConfig(): MathfieldConfigPrivate;
     getConfig(
-        keys: keyof MathfieldConfigPrivate | string[]
-    ): boolean | number | string | MathfieldConfigPrivate {
+        keys?: keyof MathfieldConfigPrivate | (keyof MathfieldConfigPrivate)[]
+    ): any | MathfieldConfigPrivate {
         return getConfig(this.config, keys);
     }
 

--- a/src/editor/mathfield-keyboard-input.ts
+++ b/src/editor/mathfield-keyboard-input.ts
@@ -115,7 +115,7 @@ export function onKeystroke(
     // 5. Let's try to find a matching shortcut or command
     let shortcut: string;
     let stateIndex: number;
-    let selector: Selector | '' | any[];
+    let selector: Selector | '' | [Selector, ...any[]];
     let resetKeystrokeBuffer = false;
     // 5.1 Check if the keystroke, prefixed with the previously typed keystrokes,
     // would match a long shortcut (i.e. '~~')

--- a/src/public/config.ts
+++ b/src/public/config.ts
@@ -99,7 +99,7 @@ export type Keybinding = {
      */
     key: string;
     /** The command is a single selector, or a selector with arguments */
-    command: Selector | any[];
+    command: Selector | [Selector, ...any[]];
     /**
      * If specified, this indicate in which mode this keybinding will apply.
      * If none is specified, the keybinding apply in every mode.

--- a/src/public/mathfield.ts
+++ b/src/public/mathfield.ts
@@ -88,7 +88,7 @@ export interface Mathfield {
     getConfig<K extends keyof MathfieldConfig>(key: K): MathfieldConfig[K];
     getConfig(): MathfieldConfig;
 
-    $setConfig(config: MathfieldConfig): void;
+    $setConfig(config: Partial<MathfieldConfig>): void;
 
     /**
      * Reverts this mathfield to its original content.

--- a/src/public/mathfield.ts
+++ b/src/public/mathfield.ts
@@ -82,9 +82,11 @@ export type InsertOptions = {
 export interface Mathfield {
     mode: ParseMode;
 
-    getConfig<T extends keyof MathfieldConfig>(key: T): MathfieldConfig[T];
-    getConfig(keys: string[]): MathfieldConfig;
-    getConfig(keys: keyof MathfieldConfig | string[]): any | MathfieldConfig;
+    getConfig<K extends keyof MathfieldConfig>(
+        keys: K[]
+    ): Pick<MathfieldConfig, K>;
+    getConfig<K extends keyof MathfieldConfig>(key: K): MathfieldConfig[K];
+    getConfig(): MathfieldConfig;
 
     $setConfig(config: MathfieldConfig): void;
 

--- a/src/public/mathfield.ts
+++ b/src/public/mathfield.ts
@@ -119,7 +119,7 @@ export interface Mathfield {
      * In the above example, both calls invoke the same selector.
      *
      */
-    $perform(command: Selector | any[]): boolean;
+    $perform(command: Selector | [Selector, ...any[]]): boolean;
 
     /**
      * Returns a textual representation of the mathfield.


### PR DESCRIPTION
This PR slightly improves some types.

I chose to use `[SelectorPrivate, ...any[]]` for now, because the August 2020 version of Visual Studio Code, which comes with Typescript 4.0, hasn't been released yet. (The expected release date is September 9)

By the way, are such minor improvements to the types `fix`es or `feat`ures?