### PR TITLE
Added getCaretPosition() and setCaretPosition()

### DIFF
--- a/src/editor/keybindings-definitions.ts
+++ b/src/editor/keybindings-definitions.ts
@@ -69,8 +69,8 @@ export const DEFAULT_KEYBINDINGS: Keybinding[] = [
         command: 'moveToPreviousPlaceholder',
     },
 
-    { key: '[Escape]', ifMode: 'math', command: ['switch-mode', 'command'] },
-    { key: '\\', ifMode: 'math', command: ['switch-mode', 'command'] },
+    { key: '[Escape]', ifMode: 'math', command: ['switchMode', 'command'] },
+    { key: '\\', ifMode: 'math', command: ['switchMode', 'command'] },
 
     {
         key: 'alt+[Equal]',
@@ -176,7 +176,7 @@ export const DEFAULT_KEYBINDINGS: Keybinding[] = [
     {
         key: 'shift+[Quote]',
         ifMode: 'text',
-        command: ['switch-mode', 'math', '”', ''],
+        command: ['switchMode', 'math', '”', ''],
     }, // ??
 
     // WOLFRAM MATHEMATICA BINDINGS

--- a/src/editor/mathfield-class.ts
+++ b/src/editor/mathfield-class.ts
@@ -932,8 +932,10 @@ export class MathfieldPrivate implements Mathfield {
             : null;
     }
     setCaretPosition(x: number, y: number): boolean {
+        const oldPath = this.model.clone();
         const anchor = pathFromPoint(this, x, y, { bias: 0 });
         const result = setPath(this.model, anchor, 0);
+        this.model.announce('move', oldPath);
         requestUpdate(this);
         return result;
     }

--- a/src/editor/mathfield-class.ts
+++ b/src/editor/mathfield-class.ts
@@ -24,6 +24,7 @@ import {
     getAnchorStyle,
     getSelectedAtoms,
     getAnchorMode,
+    setPath,
 } from './model-selection';
 import { removeSuggestion } from './model-utils';
 import {
@@ -61,7 +62,7 @@ import {
 
 import { onCut, onCopy, onPaste } from './mathfield-clipboard';
 import { attachButtonHandlers } from './mathfield-buttons';
-import { onPointerDown } from './mathfield-pointer-input';
+import { onPointerDown, pathFromPoint } from './mathfield-pointer-input';
 import {
     showVirtualKeyboard,
     hideVirtualKeyboard,
@@ -923,6 +924,20 @@ export class MathfieldPrivate implements Mathfield {
     $typedText(text: string): void {
         onTypedText(this, text);
     }
+
+    getCaretPosition(): { x: number; y: number } | null {
+        const caretPosition = getCaretPosition(this.field);
+        return caretPosition
+            ? { x: caretPosition.x, y: caretPosition.y }
+            : null;
+    }
+    setCaretPosition(x: number, y: number): boolean {
+        const anchor = pathFromPoint(this, x, y, { bias: 0 });
+        const result = setPath(this.model, anchor, 0);
+        requestUpdate(this);
+        return result;
+    }
+
     canUndo(): boolean {
         return this.undoManager.canUndo();
     }

--- a/src/editor/mathfield-utils.ts
+++ b/src/editor/mathfield-utils.ts
@@ -112,7 +112,7 @@ function findElementWithCaret(el: Element): Element {
  */
 export function getCaretPosition(
     el: Element
-): { x: number; y: number; height: number } {
+): { x: number; y: number; height: number } | null {
     const caret = findElementWithCaret(el);
     if (caret) {
         const bounds = caret.getBoundingClientRect();

--- a/src/public/mathfield.ts
+++ b/src/public/mathfield.ts
@@ -258,6 +258,9 @@ export interface Mathfield {
      * @category Changing the Content
      */
     $typedText(text: string): void;
+
+    getCaretPosition(): { x: number; y: number } | null;
+    setCaretPosition(x: number, y: number): boolean;
 }
 
 export interface Model {


### PR DESCRIPTION
I added public `getCaretPosition()` and `setCaretPosition()` methods. This fixes #101 

However, I do have some open questions that I'd like to address:

**getCaretPosition**
- It can return `null`. Is that fine? Or should it return `undefined`? 

**setCaretPosition**:
- Should it call `model.announce('move', ...)`?
- Should it focus the mathfield when calling it?
- Is the boolean return value fine or should it pick the nearest point when it is out of bounds?
