### PR TITLE
Fix non canonical text characters

### DIFF
--- a/src/core/definitions-utils.ts
+++ b/src/core/definitions-utils.ts
@@ -762,8 +762,10 @@ export function emit(
     if (atom.body && FUNCTIONS[symbol]?.params?.length === 1) {
         return symbol + '{' + emitFn(atom, atom.body as Atom[]) + '}';
     }
-    // No custom emit function provided, return the symbol (could be a character)
-    return symbol;
+
+    // No custom emit function provided, return an escaped version of the symbol
+    const hex = symbol.codePointAt(0).toString(16);
+    return '^'.repeat(hex.length) + hex;
 }
 
 export function getEnvironmentDefinition(name: string): EnvironmentDefinition {

--- a/src/core/definitions-utils.ts
+++ b/src/core/definitions-utils.ts
@@ -735,28 +735,6 @@ export function unicodeStringToLatex(
     return result;
 }
 
-/**
- *
- * @return True if command is allowed in the mode
- * (note that command can also be a single character, e.g. "a")
- */
-export function commandAllowed(
-    mode: ParseModePrivate,
-    command: string
-): boolean {
-    if (
-        FUNCTIONS[command] &&
-        (!FUNCTIONS[command].mode || FUNCTIONS[command].mode.includes(mode))
-    ) {
-        return true;
-    }
-    if ({ text: TEXT_SYMBOLS, math: MATH_SYMBOLS }[mode][command]) {
-        return true;
-    }
-
-    return false;
-}
-
 export function getValue(mode: ParseModePrivate, symbol: string): string {
     if (mode === 'math') {
         return MATH_SYMBOLS[symbol]?.value ?? symbol;

--- a/src/core/definitions-utils.ts
+++ b/src/core/definitions-utils.ts
@@ -735,11 +735,11 @@ export function unicodeStringToLatex(
     return result;
 }
 
-export function getValue(mode: ParseModePrivate, symbol: string): string {
-    if (mode === 'math') {
-        return MATH_SYMBOLS[symbol]?.value ?? symbol;
-    }
-    return TEXT_SYMBOLS[symbol] ? TEXT_SYMBOLS[symbol] : symbol;
+/**
+ * Gets the value of a symbol in math mode
+ */
+export function getValue(symbol: string): string {
+    return MATH_SYMBOLS[symbol]?.value ?? symbol;
 }
 
 export function emit(

--- a/src/core/definitions-utils.ts
+++ b/src/core/definitions-utils.ts
@@ -439,9 +439,14 @@ export function charToLatex(parseMode: ParseModePrivate, s: string): string {
         return REVERSE_MATH_SYMBOLS[s] || s;
     }
     if (parseMode === 'text') {
-        return (
-            Object.keys(TEXT_SYMBOLS).find((x) => TEXT_SYMBOLS[x] === s) || s
+        let textSymbol = Object.keys(TEXT_SYMBOLS).find(
+            (x) => TEXT_SYMBOLS[x] === s
         );
+        if (!textSymbol) {
+            const hex = s.codePointAt(0).toString(16);
+            textSymbol = '^'.repeat(hex.length) + hex;
+        }
+        return textSymbol;
     }
     return s;
 }
@@ -856,6 +861,8 @@ export function getInfo(
             info = MATH_SYMBOLS[symbol];
         } else if (TEXT_SYMBOLS[symbol]) {
             info = { value: TEXT_SYMBOLS[symbol] };
+        } else if (parseMode === 'text') {
+            info = { value: symbol };
         }
     }
 

--- a/src/core/delimiters.ts
+++ b/src/core/delimiters.ts
@@ -46,7 +46,7 @@ function makeSmallDelim(
     context: Context,
     classes = ''
 ): Span {
-    const text = makeSymbol('Main-Regular', getValue('math', delim));
+    const text = makeSymbol('Main-Regular', getValue(delim));
 
     const span = makeStyleWrap(type, text, context.mathstyle, style, classes);
 
@@ -80,7 +80,7 @@ function makeLargeDelim(
         type,
         makeSymbol(
             'Size' + size + '-Regular',
-            getValue('math', delim),
+            getValue(delim),
             'delimsizing size' + size
         ),
         context.mathstyle,
@@ -115,11 +115,7 @@ function makeInner(symbol: string, font: string): Span {
         sizeClass = ' delim-size4';
     }
 
-    return makeSymbol(
-        font,
-        getValue('math', symbol),
-        'delimsizinginner' + sizeClass
-    );
+    return makeSymbol(font, getValue(symbol), 'delimsizinginner' + sizeClass);
 }
 
 /**
@@ -140,7 +136,7 @@ function makeStackedDelim(
     let middle: string;
     let repeat: string;
     let bottom: string;
-    top = repeat = bottom = getValue('math', delim);
+    top = repeat = bottom = getValue(delim);
     middle = null;
     // Also keep track of what font the delimiters are in
     let font = 'Size1-Regular';
@@ -268,19 +264,16 @@ function makeStackedDelim(
     }
 
     // Get the metrics of the four sections
-    const topMetrics = getCharacterMetrics(getValue('math', top), font);
+    const topMetrics = getCharacterMetrics(getValue(top), font);
     const topHeightTotal = topMetrics.height + topMetrics.depth;
-    const repeatMetrics = getCharacterMetrics(getValue('math', repeat), font);
+    const repeatMetrics = getCharacterMetrics(getValue(repeat), font);
     const repeatHeightTotal = repeatMetrics.height + repeatMetrics.depth;
-    const bottomMetrics = getCharacterMetrics(getValue('math', bottom), font);
+    const bottomMetrics = getCharacterMetrics(getValue(bottom), font);
     const bottomHeightTotal = bottomMetrics.height + bottomMetrics.depth;
     let middleHeightTotal = 0;
     let middleFactor = 1;
     if (middle !== null) {
-        const middleMetrics = getCharacterMetrics(
-            getValue('math', middle),
-            font
-        );
+        const middleMetrics = getCharacterMetrics(getValue(middle), font);
         middleHeightTotal = middleMetrics.height + middleMetrics.depth;
         middleFactor = 2; // repeat symmetrically above and below middle
     }
@@ -607,7 +600,7 @@ export function makeCustomSizedDelim(
 
     // Look through the sequence
     const delimType = traverseSequence(
-        getValue('math', delim),
+        getValue(delim),
         height,
         sequence,
         context
@@ -695,10 +688,10 @@ function makeNullFence(
     return makeSpan(
         '',
         'sizing' + // @todo not useful, redundant with 'nulldelimiter'
-            // 'reset-' + context.size, 'size5',
-            // @todo: that seems like a lot of resizing... do we need both?
-            context.mathstyle.adjustTo(MATHSTYLES.textstyle) +
-            ' nulldelimiter ' + // The null delimiter has a width, specified by class 'nulldelimiter'
+        // 'reset-' + context.size, 'size5',
+        // @todo: that seems like a lot of resizing... do we need both?
+        context.mathstyle.adjustTo(MATHSTYLES.textstyle) +
+        ' nulldelimiter ' + // The null delimiter has a width, specified by class 'nulldelimiter'
             (classes || ''),
         type
     );

--- a/src/core/modes-text.ts
+++ b/src/core/modes-text.ts
@@ -293,7 +293,7 @@ function parse(
             let atoms: Atom[];
             [atoms, tokens] = options.parse('text', tokens, options);
             result = [...result, ...atoms];
-        } else if (token.length === 1) {
+        } else if ([...token].length === 1) {
             const info = getInfo(token, 'text', options.macros);
             if (!info) {
                 error({ code: 'unexpected-token' });

--- a/src/core/modes-text.ts
+++ b/src/core/modes-text.ts
@@ -293,7 +293,20 @@ function parse(
             let atoms: Atom[];
             [atoms, tokens] = options.parse('text', tokens, options);
             result = [...result, ...atoms];
-        } else if ([...token].length === 1) {
+        } else if (token === '<$>' || token === '<$$>') {
+            // Mode-shift
+            const subtokens = tokens.slice(
+                0,
+                tokens.findIndex((x: Token) => x === token)
+            );
+            tokens = tokens.slice(subtokens.length + 1);
+            const [atoms] = options.parse('math', subtokens, options);
+            result = [...result, ...atoms];
+        } else if (token === '<{>' || token === '<}>') {
+            // Spurious braces are ignored by TeX in text mode
+            // In text mode, braces are sometimes used to separate adjacent
+            // commands without inserting a space, e.g. "\backlash{}command"
+        } else {
             const info = getInfo(token, 'text', options.macros);
             if (!info) {
                 error({ code: 'unexpected-token' });
@@ -310,24 +323,6 @@ function parse(
             } else {
                 error({ code: 'unexpected-token' });
             }
-        } else if (token === '<$>' || token === '<$$>') {
-            // Mode-shift
-            const subtokens = tokens.slice(
-                0,
-                tokens.findIndex((x: Token) => x === token)
-            );
-            tokens = tokens.slice(subtokens.length + 1);
-            const [atoms] = options.parse('math', subtokens, options);
-            result = [...result, ...atoms];
-        } else if (token === '<{>' || token === '<}>') {
-            // Spurious braces are ignored by TeX in text mode
-            // In text mode, braces are sometimes used to separate adjacent
-            // commands without inserting a space, e.g. "\backlash{}command"
-        } else {
-            error({
-                code: 'unexpected-token',
-                arg: token,
-            });
         }
     }
     return [result, tokens];

--- a/src/core/tokenizer.ts
+++ b/src/core/tokenizer.ts
@@ -137,14 +137,14 @@ class Tokenizer {
             if (this.peek() === '^') {
                 // It might be a ^^ command (inline hex character)
                 this.get();
-                let hex = this.match(/^\^\^[0-9a-f][0-9a-f][0-9a-f][0-9a-f]/);
+                // There can be zero to six carets with the same number of hex digits
+                const hex = this.match(
+                    /^(\^(\^(\^(\^[0-9a-f])?[0-9a-f])?[0-9a-f])?[0-9a-f])?[0-9a-f][0-9a-f]/
+                );
                 if (hex) {
-                    // It's a ^^^^ hex char
-                    return String.fromCodePoint(parseInt(hex.slice(2), 16));
-                }
-                hex = this.match(/^[0-9a-f][0-9a-f]/);
-                if (hex) {
-                    return String.fromCodePoint(parseInt(hex, 16));
+                    return String.fromCodePoint(
+                        parseInt(hex.slice(hex.lastIndexOf('^') + 1), 16)
+                    );
                 }
             }
             return next;


### PR DESCRIPTION
Fixes #599 
(arnog, thank you very much for the guidance)

There are 3 further functions where `TEXT_SYMBOLS` is being used. I'm not sure if I should add anything to them.
- `commandAllowed`: It isn't being called anywhere
- `getValue`: It is only being called with 'math'
- `emit`: What is this function used for?