### PR TITLE
fix: Handle backspace with regards to inline shortcuts

### DIFF
--- a/src/editor/commands.ts
+++ b/src/editor/commands.ts
@@ -76,7 +76,9 @@ export function perform(
     ) as SelectorPrivate;
     if (COMMANDS[selector]?.target === 'model') {
         if (/^(delete|transpose|add)/.test(selector)) {
-            mathfield.resetKeystrokeBuffer();
+            if (selector !== 'deletePreviousChar') {
+                mathfield.resetKeystrokeBuffer();
+            }
         }
         if (
             /^(delete|transpose|add)/.test(selector) &&

--- a/src/editor/mathfield-keyboard-input.ts
+++ b/src/editor/mathfield-keyboard-input.ts
@@ -125,7 +125,17 @@ export function onKeystroke(
         mathfield.mode !== 'command' &&
         (!evt || (!evt.ctrlKey && !evt.metaKey))
     ) {
-        if (!mightProducePrintableCharacter(evt)) {
+        if (keystroke === '[Backspace]') {
+            // Special case for backspace
+            mathfield.keystrokeBuffer = mathfield.keystrokeBuffer.slice(0, -1);
+            mathfield.keystrokeBufferStates.push(mathfield.getUndoRecord());
+            if (mathfield.config.inlineShortcutTimeout) {
+                // Set a timer to reset the shortcut buffer
+                mathfield.keystrokeBufferResetTimer = setTimeout(() => {
+                    mathfield.resetKeystrokeBuffer();
+                }, mathfield.config.inlineShortcutTimeout);
+            }
+        } else if (!mightProducePrintableCharacter(evt)) {
             // It was a non-alpha character (PageUp, End, etc...)
             mathfield.resetKeystrokeBuffer();
         } else {


### PR DESCRIPTION
Fixes #198 

This is a rather simplistic way of checking if backspace was pressed and then handling it.

It doesn't really handle the case where you type `su` on the normal keyboard, then hit `[Backspace]` on the virtual keyboard and then type `m` on the normal keyboard. In fact, a number of cases where the normal and virtual keyboard are mixed don't work as expected. Furthermore, the virtual keyboard doesn't ever modify the keystroke buffer, is that intentional?

Also, I noticed that mathlive doesn't handle `su` `Ctrl+V` `m` correctly either.