### PR TITLE
editor/parse-math-string: pasting/writing `sqrt` should behave the same

### DIFF
--- a/src/editor/parse-math-string.ts
+++ b/src/editor/parse-math-string.ts
@@ -124,7 +124,8 @@ function parseMathExpression(
                 inlineShortcuts: options?.inlineShortcuts ?? {},
                 noWrap: true,
             });
-            s = '\\sqrt{' + m.match + '}';
+            const sqrtArgument = m.match || '\\placeholder{}';
+            s = '\\sqrt{' + sqrtArgument + '}';
             s += parseMathExpression(m.rest, options);
             done = true;
         }
@@ -138,7 +139,8 @@ function parseMathExpression(
                 inlineShortcuts: options?.inlineShortcuts ?? {},
                 noWrap: true,
             });
-            s = '\\sqrt[3]{' + m.match + '}';
+            const sqrtArgument = m.match || '\\placeholder{}';
+            s = '\\sqrt[3]{' + sqrtArgument + '}';
             s += parseMathExpression(m.rest, options);
             done = true;
         }


### PR DESCRIPTION
in math editor writing a `sqrt` string is translated to a
`\\sqrt{\\placeholder{}}` expression. Pasting the same `sqrt` string
into the editor is translated into a `\\sqrt{}` expression.

This happens because `parseMathExpression` does not provide
a fallback value when sqrt / sqrt[3] values are empty