### PR TITLE
fix: Don't use skipBoundary with xrightarrow and others

### DIFF
--- a/src/core/definitions-extensible-symbols.ts
+++ b/src/core/definitions-extensible-symbols.ts
@@ -105,8 +105,6 @@ defineFunction(
             svgBody: name.slice(1),
             overscript: overscript,
             underscript: args[0],
-
-            skipBoundary: true,
         };
     },
     (name, _parent, atom, emit) =>


### PR DESCRIPTION
fix #615

