### PR TITLE
Fix issue #727: The alternate keys panel renders the wrong layout for the "logic" (∀) key

### DIFF
--- a/css/virtual-keyboard.less
+++ b/css/virtual-keyboard.less
@@ -32,6 +32,10 @@
     --keyboard-alternate-background-active: #e5e5e5;
     --keyboard-alternate-text: #000;
 
+    --keyboard-alternate-key-length: 70px;
+    --keyboard-alternate-key-font-size: 30px;
+    --keyboard-alternate-key-aside-font-size: 12px;
+
     position: fixed;
     left: 0;
     bottom: -267px;
@@ -123,6 +127,13 @@
         &.is-visible {
             visibility: visible;
         }
+
+        &.compact {
+            --keyboard-alternate-key-length: 50px;
+            --keyboard-alternate-key-font-size: 24px;
+            --keyboard-alternate-key-aside-font-size: 10px;
+        }
+
         ul {
             list-style: none;
             margin: 3px;
@@ -136,16 +147,17 @@
                 flex-flow: column;
                 align-items: center;
                 justify-content: center;
-                font-size: 30px;
+                font-size: var(--keyboard-alternate-key-font-size);
 
-                height: 70px;
-                width: 70px;
+                height: var(--keyboard-alternate-key-length);
+                width: var(--keyboard-alternate-key-length);
 
                 @media only screen and (max-height: 412px) {
                     font-size: 24px;
                     height: 50px;
                     width: 50px;
                 }
+
                 box-sizing: border-box;
                 margin: 0;
                 background: transparent;
@@ -199,7 +211,7 @@
                     }
                 }
                 aside {
-                    font-size: 12px;
+                    font-size: var(--keyboard-alternate-key-aside-font-size);
                     line-height: 12px;
                     opacity: 0.78;
                     padding-top: 2px;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -74,7 +74,7 @@ echo -e "\033[2K\033[80D\033[32m ✔ \033[0m Declaration files built"
 printf "\033[32m ● \033[0m Copying static assets (fonts, sounds)"
 cp -f -R css/fonts dist/
 cp -f -R sounds dist/
-echo -e "\033[2K\033[80D\033[32m ✔ \033[0m Static assest copied"
+echo -e "\033[2K\033[80D\033[32m ✔ \033[0m Static assets copied"
 
 # Build CSS
 printf "\033[32m ● \033[0m Building static CSS"

--- a/src/editor/virtual-keyboard-commands.ts
+++ b/src/editor/virtual-keyboard-commands.ts
@@ -111,8 +111,10 @@ registerCommand(
                         altContainer.style.height = '56px'; // 1 row
                     } else if (altKeys.length <= 12) {
                         altContainer.style.height = '108px'; // 2 rows
-                    } else {
+                    } else if (altKeys.length <= 18) {
                         altContainer.style.height = '205px'; // 3 rows
+                    } else {
+                        altContainer.classList.add('compact');
                     }
                 }
                 const top =


### PR DESCRIPTION
Hopefully, I got your idea right in the discussion of the issue.

So here I've made a property evaluation for alternate keys based on variables, during the test no issues were found. Anyway if you have any concerns or suggestions to make it in another way, feel free to let me know.