### PR TITLE
Fix issue #726: Wrong behaviour of keystroke buffer

### DIFF
--- a/src/editor-mathfield/keyboard-input.ts
+++ b/src/editor-mathfield/keyboard-input.ts
@@ -166,12 +166,8 @@ export function onKeystroke(
                 mathfield.keystrokeBufferStates.length - (candidate.length - i);
             mathfield.keystrokeBuffer += c;
             mathfield.keystrokeBufferStates.push(mathfield.getUndoRecord());
-            if (
-                getInlineShortcutsStartingWith(candidate, mathfield.options)
-                    .length <= 1
-            ) {
-                resetKeystrokeBuffer = true;
-            } else {
+
+            if (shortcut) {
                 mathfield.resetKeystrokeBuffer({ defer: true });
             }
         }

--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -739,7 +739,7 @@ export class MathfieldPrivate implements Mathfield {
     resetKeystrokeBuffer(options?: { defer: boolean }): void {
         options = options ?? { defer: false };
         if (options.defer) {
-            if (this.options.inlineShortcutTimeout) {
+            if (this.options.inlineShortcutTimeout >= 0) {
                 // Set a timer to reset the shortcut buffer
                 this.keystrokeBufferResetTimer = setTimeout(() => {
                     this.resetKeystrokeBuffer();


### PR DESCRIPTION
Fix the [following issue #726](https://github.com/arnog/mathlive/issues/726)

# Cause 1
The first cause of wrong behaviour that is incorrect option validation in `resetKeystrokeBuffer` method.
It was a `if (this.options.inlineShortcutTimeout) {` and default value of `inlineShortcutTimeout` options is `0` that leads to `false` evaluation of condition and keystroke buffer is not reseted with `defer` option.

# Cause 2
The logic for resetting the keystroke buffer was strange and actually reseted everytime after fixing the first cause, so I change logic to reset buffer only when shortcut to insert was found. I'm not sure that new logic is correct, please mention if I not check some special cases for shortcuts