### PR TITLE
add Data command to add data properties to dom elements

### DIFF
--- a/src/addons/definitions-metadata.ts
+++ b/src/addons/definitions-metadata.ts
@@ -188,6 +188,7 @@ metadata(
     '\\ttfamily',
     '\\class',
     '\\cssId',
+    '\\data',
   ],
   RARE,
   '{$0 Don Knuth}'

--- a/src/addons/definitions-metadata.ts
+++ b/src/addons/definitions-metadata.ts
@@ -188,7 +188,7 @@ metadata(
     '\\ttfamily',
     '\\class',
     '\\cssId',
-    '\\data',
+    '\\htmlData',
   ],
   RARE,
   '{$0 Don Knuth}'

--- a/src/core-atoms/group.ts
+++ b/src/core-atoms/group.ts
@@ -9,6 +9,7 @@ export class GroupAtom extends Atom {
   latexOpen?: string;
   latexClose?: string;
   cssId?: string;
+  data?: string;
   customClass?: string;
   mathStyleName: MathStyleName;
   constructor(
@@ -18,6 +19,7 @@ export class GroupAtom extends Atom {
       latexOpen?: string;
       latexClose?: string;
       cssId?: string;
+      data?: string;
       customClass?: string;
       mode?: ParseMode;
       style?: Style;
@@ -35,6 +37,7 @@ export class GroupAtom extends Atom {
     this.latexOpen = options?.latexOpen;
     this.latexClose = options?.latexClose;
     this.cssId = options?.cssId;
+    this.data = options?.data;
     this.customClass = options?.customClass;
 
     this.skipBoundary = true;
@@ -54,6 +57,7 @@ export class GroupAtom extends Atom {
     });
     const span = new Span(Atom.render(localContext, this.body), '', 'mord'); // @revisit
     if (this.cssId) span.cssId = this.cssId;
+    if (this.data) span.data = this.data;
     span.applyStyle(
       this.mode,
       {
@@ -80,7 +84,9 @@ export class GroupAtom extends Atom {
     if (this.cssId) {
       return `\\cssId{${this.cssId}}${body}}`;
     }
-
+    if (this.data) {
+      return `\\data{${this.data}}${body}}`;
+    }
     if (this.customClass) {
       return `\\class{${this.customClass}}${body}}`;
     }

--- a/src/core-atoms/group.ts
+++ b/src/core-atoms/group.ts
@@ -9,7 +9,7 @@ export class GroupAtom extends Atom {
   latexOpen?: string;
   latexClose?: string;
   cssId?: string;
-  data?: string;
+  htmlData?: string;
   customClass?: string;
   mathStyleName: MathStyleName;
   constructor(
@@ -19,7 +19,7 @@ export class GroupAtom extends Atom {
       latexOpen?: string;
       latexClose?: string;
       cssId?: string;
-      data?: string;
+      htmlData?: string;
       customClass?: string;
       mode?: ParseMode;
       style?: Style;
@@ -37,7 +37,7 @@ export class GroupAtom extends Atom {
     this.latexOpen = options?.latexOpen;
     this.latexClose = options?.latexClose;
     this.cssId = options?.cssId;
-    this.data = options?.data;
+    this.htmlData = options?.htmlData;
     this.customClass = options?.customClass;
 
     this.skipBoundary = true;
@@ -57,7 +57,7 @@ export class GroupAtom extends Atom {
     });
     const span = new Span(Atom.render(localContext, this.body), '', 'mord'); // @revisit
     if (this.cssId) span.cssId = this.cssId;
-    if (this.data) span.data = this.data;
+    if (this.htmlData) span.htmlData = this.htmlData;
     span.applyStyle(
       this.mode,
       {
@@ -84,8 +84,8 @@ export class GroupAtom extends Atom {
     if (this.cssId) {
       return `\\cssId{${this.cssId}}${body}}`;
     }
-    if (this.data) {
-      return `\\data{${this.data}}${body}}`;
+    if (this.htmlData) {
+      return `\\htmlData{${this.htmlData}}${body}}`;
     }
     if (this.customClass) {
       return `\\class{${this.customClass}}${body}}`;

--- a/src/core-definitions/styling.ts
+++ b/src/core-definitions/styling.ts
@@ -495,10 +495,10 @@ defineFunction('cssId', '{id:string}{content:auto}', {
 });
 
 /*  assign an property to the element */
-defineFunction('data', '{data:string}{content:auto}', {
+defineFunction('htmlData', '{data:string}{content:auto}', {
   createAtom: (command: string, args: Argument[], style: Style): Atom =>
     new GroupAtom(args[1] as Atom[], {
-      data: args[0] as string,
+      htmlData: args[0] as string,
       style,
     }),
 });

--- a/src/core-definitions/styling.ts
+++ b/src/core-definitions/styling.ts
@@ -494,7 +494,7 @@ defineFunction('cssId', '{id:string}{content:auto}', {
     }),
 });
 
-/* A MathJax extension: assign an ID to the element */
+/*  assign an property to the element */
 defineFunction('data', '{data:string}{content:auto}', {
   createAtom: (command: string, args: Argument[], style: Style): Atom =>
     new GroupAtom(args[1] as Atom[], {

--- a/src/core-definitions/styling.ts
+++ b/src/core-definitions/styling.ts
@@ -494,6 +494,15 @@ defineFunction('cssId', '{id:string}{content:auto}', {
     }),
 });
 
+/* A MathJax extension: assign an ID to the element */
+defineFunction('data', '{data:string}{content:auto}', {
+  createAtom: (command: string, args: Argument[], style: Style): Atom =>
+    new GroupAtom(args[1] as Atom[], {
+      data: args[0] as string,
+      style,
+    }),
+});
+
 /* Note: in TeX, \em is restricted to text mode. We extend it to math
  * This is the 'switch' variant of \emph, i.e:
  * `\emph{important text}`

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -1410,7 +1410,7 @@ class Parser {
 
     if (
       result instanceof Atom &&
-      !/^\\(llap|rlap|class|cssId|data)$/.test(command)
+      !/^\\(llap|rlap|class|cssId|htmlData)$/.test(command)
     ) {
       const argString = tokensToString(
         this.tokens.slice(initialIndex, this.index)

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -1410,7 +1410,7 @@ class Parser {
 
     if (
       result instanceof Atom &&
-      !/^\\(llap|rlap|class|cssId)$/.test(command)
+      !/^\\(llap|rlap|class|cssId|data)$/.test(command)
     ) {
       const argString = tokensToString(
         this.tokens.slice(initialIndex, this.index)

--- a/src/core/span.ts
+++ b/src/core/span.ts
@@ -136,6 +136,7 @@ function toString(arg: (string | number)[] | string | number): string {
  * @property classes - A string of space separated CSS classes
  * associated with this element
  * @property cssId - A CSS ID assigned to this span (optional)
+ * @property data - data fields assigned to this span (optional)
  * @property children - An array, potentially empty, of spans which
  * this span encloses
  * @property body - Content of this span. Can be empty.
@@ -166,6 +167,7 @@ export class Span {
   isTight?: boolean;
 
   cssId?: string;
+  data?: string;
 
   svgBody?: string;
   svgOverlay?: string;
@@ -426,6 +428,7 @@ export class Span {
       (body === '\u200B' || (!body && !this.svgBody)) &&
       !this.classes &&
       !this.cssId &&
+      !this.data &&
       !this.style &&
       !this.svgOverlay
     ) {
@@ -438,6 +441,24 @@ export class Span {
 
       if (this.cssId) {
         result += ' id="' + this.cssId + '" ';
+      }
+
+      if (this.attributes) {
+        result +=
+          ' ' +
+          Object.keys(this.attributes)
+            .map((x) => `${x}="${this.attributes[x]}"`)
+            .join(' ');
+      }
+
+      if (this.data) {
+        const entries = this.data.split(',');
+        for (const entry of entries) {
+          const matched = entry.match(/([^=]+)=(.+$)/);
+          if (matched) {
+            result += `udata-${matched[1]}=${matched[2]} `;
+          }
+        }
       }
 
       if (this.attributes) {

--- a/src/core/span.ts
+++ b/src/core/span.ts
@@ -443,14 +443,6 @@ export class Span {
         result += ' id="' + this.cssId + '" ';
       }
 
-      if (this.attributes) {
-        result +=
-          ' ' +
-          Object.keys(this.attributes)
-            .map((x) => `${x}="${this.attributes[x]}"`)
-            .join(' ');
-      }
-
       if (this.data) {
         const entries = this.data.split(',');
         for (const entry of entries) {
@@ -459,6 +451,14 @@ export class Span {
             result += `udata-${matched[1]}=${matched[2]} `;
           }
         }
+      }
+
+      if (this.attributes) {
+        result +=
+          ' ' +
+          Object.keys(this.attributes)
+            .map((x) => `${x}="${this.attributes[x]}"`)
+            .join(' ');
       }
 
       if (this.attributes) {

--- a/src/core/span.ts
+++ b/src/core/span.ts
@@ -461,14 +461,6 @@ export class Span {
             .join(' ');
       }
 
-      if (this.attributes) {
-        result +=
-          ' ' +
-          Object.keys(this.attributes)
-            .map((x) => `${x}="${this.attributes[x]}"`)
-            .join(' ');
-      }
-
       const classes = this.classes.split(' ');
 
       // Add the type (mbin, mrel, etc...) if specified

--- a/src/core/span.ts
+++ b/src/core/span.ts
@@ -136,7 +136,7 @@ function toString(arg: (string | number)[] | string | number): string {
  * @property classes - A string of space separated CSS classes
  * associated with this element
  * @property cssId - A CSS ID assigned to this span (optional)
- * @property data - data fields assigned to this span (optional)
+ * @property htmlData - data fields assigned to this span (optional)
  * @property children - An array, potentially empty, of spans which
  * this span encloses
  * @property body - Content of this span. Can be empty.
@@ -167,7 +167,7 @@ export class Span {
   isTight?: boolean;
 
   cssId?: string;
-  data?: string;
+  htmlData?: string;
 
   svgBody?: string;
   svgOverlay?: string;
@@ -428,7 +428,7 @@ export class Span {
       (body === '\u200B' || (!body && !this.svgBody)) &&
       !this.classes &&
       !this.cssId &&
-      !this.data &&
+      !this.htmlData &&
       !this.style &&
       !this.svgOverlay
     ) {
@@ -443,12 +443,12 @@ export class Span {
         result += ' id="' + this.cssId + '" ';
       }
 
-      if (this.data) {
-        const entries = this.data.split(',');
+      if (this.htmlData) {
+        const entries = this.htmlData.split(',');
         for (const entry of entries) {
           const matched = entry.match(/([^=]+)=(.+$)/);
           if (matched) {
-            result += `udata-${matched[1]}=${matched[2]} `;
+            result += `data-${matched[1]}=${matched[2]} `;
           }
         }
       }


### PR DESCRIPTION
It basically mimics what was done for cssId, to add a command.   Addresses #785 

fields added have a form udata-* to avoid conflict with data- fields that mathlive already adds.
