### PR TITLE
Add display = [] to example code to make code snippet valid

### DIFF
--- a/tutorials/USAGE_GUIDE.md
+++ b/tutorials/USAGE_GUIDE.md
@@ -145,6 +145,7 @@ MathLive.renderMathInElement(document.getElementById('formulas'), {
                 ['$', '$'],
                 ['\\(', '\\)'],
             ],
+            display: [],
         },
     },
 });


### PR DESCRIPTION
Currently the code snippet is invalid, since the mandetory `display` key is not included. I would argue that is is a good idea to have only working code in the documentation.