### PR TITLE
Remove whitespaces within mathfield span

### DIFF
--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -274,12 +274,11 @@ export class MathfieldPrivate implements Mathfield {
     }
 
     markup += '</span>';
-    markup += `
-        <div class="ML__sr-only">
-            <span aria-live="assertive" aria-atomic="true"></span>
-            <span></span>
-        </div>
-    `;
+    markup += 
+        '<div class="ML__sr-only">' +
+            '<span aria-live="assertive" aria-atomic="true"></span>' +
+            '<span></span>' +
+        '</div>';
 
     this.element.innerHTML = this.options.createHTML(markup);
     if (!this.element.children) {


### PR DESCRIPTION
Here is what the spaces look like in css inspector. This issue is causing problems with allowing for a `ML__fieldcontainer` to have `display: inline`.

https://imgur.com/WB5K6w6