### PR TITLE
Fix #833 : custom virtual keyboard not displaying

### DIFF
--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -576,6 +576,11 @@ export class MathfieldPrivate implements Mathfield {
       suppressChangeNotifications: true,
       macros: this.options.macros,
     });
+
+    this.virtualKeyboard = new VirtualKeyboard(this.options, {
+      executeCommand: (command) => this.executeCommand(command),
+    });
+
     requestUpdate(this);
   }
 


### PR DESCRIPTION
Using setOptions on a mathfield, the virtualKeyboard field was not reinitialized with the new options.