### PR TITLE
Allow appending the virtual keyboard to an arbitrary element

### DIFF
--- a/src/editor/options.ts
+++ b/src/editor/options.ts
@@ -204,6 +204,10 @@ export function update(
         }
 
         break;
+      case 'virtualKeyboardAppendTarget':
+        result.virtualKeyboardAppendTarget =
+          updates.virtualKeyboardAppendTarget;
+        break;
       case 'onBlur':
       case 'onFocus':
       case 'onContentWillChange':
@@ -325,6 +329,7 @@ export function getDefault(): Required<MathfieldOptionsPrivate> {
     keypressSound: null,
     plonkSound: null,
     virtualKeyboardToolbar: 'default',
+    virtualKeyboardAppendTarget: document.body,
 
     useSharedVirtualKeyboard: false,
     sharedVirtualKeyboardTargetOrigin: window.origin,

--- a/src/editor/virtual-keyboard-commands.ts
+++ b/src/editor/virtual-keyboard-commands.ts
@@ -346,7 +346,9 @@ function toggleVirtualKeyboard(
       on(keyboard.element, 'touchstart:passive mousedown', () =>
         keyboard.focusMathfield()
       );
-      document.body.append(keyboard.element);
+      keyboard.options.virtualKeyboardAppendTarget.appendChild(
+        keyboard.element
+      );
     }
 
     // For the transition effect to work, the property has to be changed

--- a/src/public/options.ts
+++ b/src/public/options.ts
@@ -474,6 +474,12 @@ export type VirtualKeyboardOptions = {
    *
    */
   virtualKeyboardMode: 'auto' | 'manual' | 'onfocus' | 'off';
+  /**
+   * Target element the virtual keyboard element gets appended to.
+   *
+   * **Default**: `document.body`
+   */
+  virtualKeyboardAppendTarget?: HTMLElement;
 };
 
 /**


### PR DESCRIPTION
I added a new option, `virtualKeyboardAppendTarget`, that enables customization of where in the DOM the virtual keyboard gets inserted. 

The use case for this is having a working keyboard when [full screening DOM elements](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API) that contain MathLive, eg.

```html
// ...

<div id='container'>
  <div id='math-field'></div>
</div>
<button id='toggle-fullscreen'>Toggle fullscreen</button>

<script type='module'>
  import MathLive from 'mathlive'

  const container = document.getElementById('container')
  document.getElementById('toggle-fullscreen')
    .addEventListener('click', () => container.requestFullscreen())

  const mathField = document.getElementById('math-field')  
  MathLive.makeMathField(mathField, {
    virtualKeyboardMode: 'onfocus',
    virtualKeyboardAppendTarget: container
  })
</script>

// ...
```

Currently, on `master`, the keyboard isn't visible after clicking the Toggle fullscreen button and focusing the MathLive input because it renders outside of `#container` which is fullscreened. This commit fixes that. 