### PR TITLE
Fix loosing brackets in mathfield for htmlData class cssId tex commands

### DIFF
--- a/src/core-atoms/group.ts
+++ b/src/core-atoms/group.ts
@@ -85,13 +85,13 @@ export class GroupAtom extends Atom {
     }
 
     if (this.htmlData) {
-      result = `\\htmlData{${this.htmlData}}${result}`;
+      result = `\\htmlData{${this.htmlData}}{${result}}`;
     }
     if (this.customClass) {
-      result = `\\class{${this.customClass}}${result}`;
+      result = `\\class{${this.customClass}}{${result}}`;
     }
     if (this.cssId) {
-      result = `\\cssId{${this.cssId}}${result}`;
+      result = `\\cssId{${this.cssId}}{${result}}`;
     }
 
     return result;


### PR DESCRIPTION
### Description
When typing `\htmlData{test:test}{x=0}` in mathfield than adding something else - tex code looses brackets in second part of command. For example ` \htmlData{test:test}{x=0}` => `\htmlData{test:test}x=0somethingelse`. `\class`, `\cssId` has the same behaviour.
### Expected result
`\htmlData{test:test}{x=0}` => `\htmlData{test:test}{x=0somethingelse}`