### PR TITLE
package: add @typescript-eslint/parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@types/css-font-loading-module": "0.0.4",
     "@types/jest": "^26.0.23",
     "@typescript-eslint/eslint-plugin": "^4.26.1",
+    "@typescript-eslint/parser": "^4.26.1",
     "autoprefixer": "10.2.6",
     "check-node-version": "^4.1.0",
     "cssnano": "^5.0.5",


### PR DESCRIPTION
add to dev dependencies @typescript-eslint/parser package.
This fixes the following error during install:

[!] (plugin eslint) Error: Failed to load parser
'@typescript-eslint/parser' declared in '.eslintrc.json':
Cannot find module '@typescript-eslint/parser'
Require stack:
- /home/web/mathlive/.eslintrc.json