### PR TITLE
fix: navigator access on the server

### DIFF
--- a/src/common/capabilities.ts
+++ b/src/common/capabilities.ts
@@ -31,6 +31,10 @@ export function osPlatform():
   | 'ios'
   | 'chromeos'
   | 'other' {
+  if (!isBrowser()) {
+    return 'other';
+  }
+
   const platform = navigator.platform;
 
   if (/^(mac)/i.test(platform)) {

--- a/src/editor/keybindings.ts
+++ b/src/editor/keybindings.ts
@@ -11,13 +11,13 @@ import {
 } from './keyboard-layout';
 import { REVERSE_KEYBINDINGS } from './keybindings-definitions';
 import type { ParseMode } from '../public/core';
-import { osPlatform } from '../common/capabilities';
+import { isBrowser, osPlatform } from '../common/capabilities';
 
 /**
  * @param p The platform to test against.
  */
 function matchPlatform(p: string): boolean {
-  if (navigator?.platform && navigator?.userAgent) {
+  if (isBrowser() && navigator?.platform && navigator?.userAgent) {
     const plat = osPlatform();
     const isNeg = p.startsWith('!');
     const isMatch = p.endsWith(plat);

--- a/src/editor/l10n.ts
+++ b/src/editor/l10n.ts
@@ -1,5 +1,6 @@
 // Import { Keys } from '../types-utils';
 import { STRINGS } from './l10n-strings';
+import { isBrowser } from '../common/capabilities';
 
 interface L10n {
   locale: string;
@@ -30,7 +31,8 @@ export const l10n: L10n = {
     // "english" if not running in a browser (node.js)
     if (!l10n._locale) {
       // Use the setter, which will load the necessary .json files.
-      l10n._locale = navigator?.language.slice(0, 5) ?? 'en';
+      l10n._locale =
+        (isBrowser() ? navigator?.language.slice(0, 5) : null) ?? 'en';
     }
 
     return l10n._locale;

--- a/src/editor/options.ts
+++ b/src/editor/options.ts
@@ -13,7 +13,7 @@ import { l10n } from './l10n';
 import { defaultAnnounceHook } from './a11y';
 import { DEFAULT_KEYBINDINGS } from './keybindings-definitions';
 import { resolveRelativeUrl } from '../common/script-url';
-import { isTouchCapable } from '../common/capabilities';
+import { isBrowser, isTouchCapable } from '../common/capabilities';
 import { getDefaultRegisters } from '../core/registers';
 import { defaultSpeakHook } from './speech';
 import { defaultReadAloudHook } from './speech-read-aloud';
@@ -108,7 +108,7 @@ export function update(
       case 'locale':
         result.locale =
           updates.locale === 'auto'
-            ? navigator?.language.slice(0, 5) ?? 'en'
+            ? (isBrowser() ? navigator?.language.slice(0, 5) : null) ?? 'en'
             : updates.locale!;
         l10n.locale = result.locale;
         break;
@@ -335,7 +335,9 @@ export function getDefault(): Required<MathfieldOptionsPrivate> {
     virtualKeyboardLayout: 'auto',
     customVirtualKeyboardLayers: {},
     customVirtualKeyboards: {},
-    virtualKeyboardTheme: /android|cros/i.test(navigator?.userAgent)
+    virtualKeyboardTheme: /android|cros/i.test(
+      isBrowser() ? navigator?.userAgent : ''
+    )
       ? 'material'
       : 'apple',
     keypressVibration: true,

--- a/src/editor/speech-read-aloud.ts
+++ b/src/editor/speech-read-aloud.ts
@@ -60,7 +60,7 @@ export function defaultReadAloudHook(
   text: string,
   config: Partial<MathfieldOptions>
 ): void {
-  if (!window) {
+  if (typeof window === 'undefined') {
     return;
   }
 
@@ -229,7 +229,7 @@ export function readAloudStatus():
   | 'playing'
   | 'paused'
   | 'unavailable' {
-  if (!window) return 'unavailable';
+  if (typeof window === 'undefined') return 'unavailable';
   window.mathlive = window.mathlive ?? {};
 
   if (!window.mathlive.readAloudAudio) return 'ready';
@@ -245,7 +245,7 @@ export function readAloudStatus():
  * **See** {@linkcode speak}
  */
 export function pauseReadAloud(): void {
-  if (!window) return;
+  if (typeof window === 'undefined') return;
   window.mathlive = window.mathlive ?? {};
   if (window.mathlive.readAloudAudio) {
     if (window.mathlive.onReadAloudStatus) {
@@ -265,7 +265,7 @@ export function pauseReadAloud(): void {
  * **See** {@linkcode speak}
  */
 export function resumeReadAloud(): void {
-  if (!window) return;
+  if (typeof window === 'undefined') return;
   window.mathlive = window.mathlive ?? {};
   if (window.mathlive.readAloudAudio) {
     if (window.mathlive.onReadAloudStatus) {
@@ -287,7 +287,7 @@ export function resumeReadAloud(): void {
  * @param count The number of tokens to read.
  */
 export function playReadAloud(token: string, count: number): void {
-  if (!window) return;
+  if (typeof window === 'undefined') return;
   window.mathlive = window.mathlive ?? {};
   if (window.mathlive.readAloudAudio) {
     let timeIndex = 0;

--- a/src/public/mathfield-element.ts
+++ b/src/public/mathfield-element.ts
@@ -19,7 +19,7 @@ import {
 } from '../editor/options';
 import { MathfieldPrivate } from '../editor-mathfield/mathfield-private';
 import { isOffset, isRange, isSelection } from '../editor/model';
-import { throwIfNotInBrowser } from '../common/capabilities';
+import { isBrowser, throwIfNotInBrowser } from '../common/capabilities';
 
 //
 // Custom Events
@@ -1729,7 +1729,7 @@ declare global {
   }
 }
 
-if (!window.customElements?.get('math-field')) {
+if (isBrowser() && !window.customElements?.get('math-field')) {
   window.MathfieldElement = MathfieldElement;
   window.customElements?.define('math-field', MathfieldElement);
 }


### PR DESCRIPTION
Seems like the optional chaining operator wasn't enough to guard against `ReferenceError` on the server. This PR will add guards wherever `navigator` may be unsafely accessed.

Will also do the same for `window`.