### PR TITLE
Reduce mathfield min height

### DIFF
--- a/css/mathfield.less
+++ b/css/mathfield.less
@@ -60,7 +60,7 @@
   flex-flow: row;
   justify-content: space-between;
   align-items: flex-end;
-  min-height: 39px; /* Need some room for the virtual keyboard toggle */
+  min-height: 12px; /* Need some room for the virtual keyboard toggle */
 
   /* Prevent the browser from trying to interpret touch gestures in the field */
   /* "Disabling double-tap to zoom removes the need for browsers to


### PR DESCRIPTION
This mostly prevents something I've asked about on Gitter

> I realize that this is a bit of an application specific question, but is there a way of making the `ML__fieldcontainer__field` take up the size of its parent (`ML__fieldcontainer`)?
> Currently, it's possible to have a field that's a bit smaller than its parent, leading to the user pressing in the mathfield and wondering why the caret doesn't get placed anywhere
> ![image](https://files.gitter.im/5dc489c5d73408ce4fd0554d/bUXP/image.png)
> 