### PR TITLE
start: use serve-http instead of http-serve to fix node 14 bug w/ linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "eslint-plugin-no-unsanitized": "^3.1.5",
     "eslint-plugin-prettier": "^3.4.1",
     "estrella": "^1.4.1",
+    "http-server": "^13.0.2",
     "husky": "^7.0.2",
     "jest": "^27.1.0",
     "jest-silent-reporter": "^0.5.0",
@@ -107,7 +108,6 @@
     "rollup-plugin-postcss": "^4.0.1",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.30.0",
-    "serve-http": "^1.0.6",
     "ts-jest": "^27.0.5",
     "typescript": "^4.4.2"
   },

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -3,15 +3,8 @@
 const { build } = require('estrella');
 const open = require('open');
 const less = require('@arnog/esbuild-plugin-less');
+const { exec } = require('child_process');
 
-// function getOutputFilename(rootName, format) {
-//   switch (format) {
-//     case 'esm':
-//       return `${rootName}.mjs`;
-//     default:
-//       return `${rootName}.js`;
-//   }
-// }
 
 let server = null;
 
@@ -39,51 +32,18 @@ build({
     if (server === null && buildResult.errors.length === 0) {
       const url = `http://localhost:8080/examples/test-cases/`;
       console.log(` 🚀 Server ready:\u001b[1;35m ${url}\u001b[0m`);
+      exec(
+        "npx http-server . -s -c-1 --cors='*' --port 8080",
+        (error, stdout, stderr) => {
+          if (error) {
+            throw Error(error)
+          }
+          console.log(stdout);
+          console.error(stderr);
+        }
+      );
 
-      server = require('serve-http').createServer({
-        host: 'localhost',
-        port: 8080,
-        pubdir: '.',
-        quiet: true,
-        defaultMimeType: 'text/javascript',
-        // livereload: { disable: true },
-      });
       open(url);
     }
   },
 });
-
-// } else {
-//   ['esm', 'iife'].forEach((format) => {
-//     const outputFilename = getOutputFilename('mathlive', format);
-//     build({
-//       watch:
-//         process.env.BUILD !== 'watch'
-//           ? false
-//           : {
-//               onRebuild(error) {
-//                 if (!error) {
-//                   console.log('Build succeeded');
-//                 }
-//               },
-//             },
-//       entryPoints: ['./src/mathlive.ts'],
-//       bundle: true,
-//       format,
-//       globalName: 'MathLive',
-//       // outdir: path.resolve(__dirname, 'build'),
-//       outfile: `./dist/${outputFilename}`,
-//       plugins: [cssFilePlugin()],
-//       loader: {
-//         '.ts': 'ts',
-//       },
-//     })
-//       .then(() => {
-//         console.info(`— ${outputFilename} was built`);
-//       })
-//       .catch((e) => {
-//         console.info(`🚨 ${outputFilename} build error:`);
-//         console.error(e);
-//       });
-//   });
-// }


### PR DESCRIPTION
serve-http has an issue with a node >= 14 fs.watch breaking
change on linux causing the server to crash.
on efea7a7a0080870712cdc81a394435b4953e38d1, while introducing
estrella, serve-http was dismissed in favor of http-serve.

In order to be able to run a server on linux machines,
let's re-introduce http-server

rif. https://github.com/rsms/serve-http/issues/6