### PR TITLE
Fix #1087 - math-field scrolling on input inconsistent behavior

### DIFF
--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -972,6 +972,10 @@ export class MathfieldPrivate implements Mathfield {
         void this.keypressSound?.play().catch(console.warn);
       }
 
+      if (options.scrollIntoView) {
+        this.scrollIntoView();
+      }
+
       if (s === '\\\\') {
         // This string is interpreted as an "insert row after" command
         addRowAfter(this.model);

--- a/src/editor/commands.ts
+++ b/src/editor/commands.ts
@@ -218,7 +218,9 @@ export function performWithFeedback(
     mathfield.keypressSound?.play().catch(console.warn);
   }
 
-  return mathfield.executeCommand(selector);
+  const result = mathfield.executeCommand(selector);
+  mathfield.scrollIntoView();
+  return result;
 }
 
 register({

--- a/src/editor/virtual-keyboard-utils.ts
+++ b/src/editor/virtual-keyboard-utils.ts
@@ -1458,6 +1458,7 @@ export function makeKeycap(
         {
           focus: true,
           feedback: true,
+          scrollIntoView: true,
           mode: 'math',
           format: 'latex',
           resetStyle: true,
@@ -1470,6 +1471,7 @@ export function makeKeycap(
         {
           focus: true,
           feedback: true,
+          scrollIntoView: true,
           mode: 'math',
           format: 'latex',
           resetStyle: true,

--- a/src/public/mathfield.ts
+++ b/src/public/mathfield.ts
@@ -77,6 +77,9 @@ export type InsertOptions = {
   /** If true, provide audio and haptic feedback
    */
   feedback?: boolean;
+  /** If true, scroll the caret into view after insertion
+   */
+  scrollIntoView?: boolean;
   /** If true, the style after the insertion
    * is the same as the style before. If false, the style after the
    * insertion is the style of the last inserted atom.


### PR DESCRIPTION
Hello 👋 I was able to tackle part of the problem discussed in #1087.
This change enables the field to scroll after input for command that are using the `performWithFeedback` method, with the same behavior as keybindings and typedText.

This alone will allow to move the caret in the math-field using the left/right buttons in the virtual keyboard with the same experience as using the arrow keys on the physical keyboard.

I'm still figuring out how to extend this fix to buttons that use the `insert` method.
Any help in this direction would be wonderful!

