### PR TITLE
Fix tabbing out of empty fields and the beginning of fields

### DIFF
--- a/src/editor-model/commands-move.ts
+++ b/src/editor-model/commands-move.ts
@@ -322,7 +322,6 @@ function leap(
       (atom.treeDepth > 2 && atom.isFirstSibling && atom.isLastSibling)
   );
 
-
   // If no placeholders were found, call handler or move to the next focusable
   // element in the document
   if (placeholders.length === 0) {

--- a/src/editor-model/commands-move.ts
+++ b/src/editor-model/commands-move.ts
@@ -314,13 +314,14 @@ function leap(
   // Candidate placeholders are atom of type 'placeholder'
   // or empty children list (except for the root: if the root is empty,
   // it is not a valid placeholder)
-  const atoms = model.getAllAtoms(model.position + dist);
+  const atoms = model.getAllAtoms(Math.max(model.position + dist, 0));
   if (dir === 'backward') atoms.reverse();
   const placeholders = atoms.filter(
     (atom) =>
       atom.type === 'placeholder' ||
-      (atom.treeDepth > 0 && atom.isFirstSibling && atom.isLastSibling)
+      (atom.treeDepth > 2 && atom.isFirstSibling && atom.isLastSibling)
   );
+
 
   // If no placeholders were found, call handler or move to the next focusable
   // element in the document


### PR DESCRIPTION
This PR fixes [two small issues](https://user-images.githubusercontent.com/446007/139747586-5794027c-dd05-4a0c-a253-85fd0223cab8.mp4):
1. When tabbing out of an empty field, very often nothing happens. You may have to jam on the button a lot to get it to work.
    - This was fixed by detecting the "root" atom more accurately. I'm not 100% confident in this fix, but `treeDepth` as currently implement was never going to be less than 1. When the field is empty, the atom you get has a `treeDepth` of 2.
2. When shift-tabbing out with the cursor at the beginning of a field, it takes two inputs to shift-tab out.
    - This was fixed by clamping the index passed to `getAllAtoms`; when at the beginning of a field, we would pass `-1`, which would cause us to return `undefined` as an atom.


