### PR TITLE
Add sounds-directory to list of valid attributes

### DIFF
--- a/src/public/mathfield-element.ts
+++ b/src/public/mathfield-element.ts
@@ -566,6 +566,7 @@ export class MathfieldElement extends HTMLElement implements Mathfield {
     return {
       'default-mode': 'string',
       'fonts-directory': 'string',
+      'sounds-directory': 'string',
       'horizontal-spacing-scale': 'string',
       'math-mode-space': 'string',
       'inline-shortcut-timeout': 'string',


### PR DESCRIPTION
The `soundsDirectory` option wasn't an attribute in the `optionsAttributes` array, meaning it wouldn't work if you set it from an attribute.

This is needed because MathLive tries to load the fonts and sounds immediately from the constructor. If it fails, it sends a bunch of errors to the console. In order to prevent this first set of errors, you'd need to pass these directories into the constructor:
```javascript
const mfe = new MathfieldElement({soundsDirectory: ..., fontsDirectory: ...})
```

However, we're not using this constructor -- we're using a Virtual DOM setup (in Elm) that directly adds a custom element to the DOM through `document.createElement`. Thus, our only option to suppress the first set of errors is to set the directories as an attribute.