### PR TITLE
added commnad "\HTMLStyle" to support html styling

### DIFF
--- a/src/addons/definitions-metadata.ts
+++ b/src/addons/definitions-metadata.ts
@@ -189,6 +189,7 @@ metadata(
     '\\class',
     '\\cssId',
     '\\htmlData',
+    '\\htmlStyle',
   ],
   RARE,
   '{$0 Don Knuth}'

--- a/src/core-atoms/group.ts
+++ b/src/core-atoms/group.ts
@@ -10,6 +10,7 @@ export class GroupAtom extends Atom {
   latexClose?: string;
   cssId?: string;
   htmlData?: string;
+  htmlStyle?: string;
   customClass?: string;
   mathstyleName?: MathstyleName;
   boxType?: BoxType;
@@ -23,6 +24,7 @@ export class GroupAtom extends Atom {
       latexClose?: string;
       cssId?: string;
       htmlData?: string;
+      htmlStyle?: string;
       customClass?: string;
       mode?: ParseMode;
       style?: Style;
@@ -43,6 +45,7 @@ export class GroupAtom extends Atom {
     this.latexClose = options?.latexClose;
     this.cssId = options?.cssId;
     this.htmlData = options?.htmlData;
+    this.htmlStyle = options?.htmlStyle;
     this.customClass = options?.customClass;
 
     this.boxType = options?.boxType;
@@ -71,6 +74,7 @@ export class GroupAtom extends Atom {
     if (!box) return box;
     if (this.cssId) box.cssId = this.cssId;
     if (this.htmlData) box.htmlData = this.htmlData;
+    if (this.htmlStyle) box.htmlStyle = this.htmlStyle;
     if (this.caret) box.caret = this.caret;
     // Need to bind the group so that the DOM element can be matched
     // and the atom iterated recursively. Otherwise, it behaves
@@ -87,6 +91,9 @@ export class GroupAtom extends Atom {
 
     if (this.htmlData) {
       result = `\\htmlData{${this.htmlData}}{${result}}`;
+    }
+    if (this.htmlStyle) {
+      result = `\\htmlStyle{${this.htmlStyle}}{${result}}`;
     }
     if (this.customClass) {
       result = `\\class{${this.customClass}}{${result}}`;

--- a/src/core-definitions/styling.ts
+++ b/src/core-definitions/styling.ts
@@ -561,6 +561,14 @@ defineFunction('htmlData', '{data:string}{content:auto}', {
     }),
 });
 
+defineFunction('htmlStyle', '{data:string}{content:auto}', {
+  createAtom: (command: string, args: Argument[], style: PrivateStyle): Atom =>
+    new GroupAtom(args[1] as Atom[], {
+      htmlStyle: args[0] as string,
+      style,
+    }),
+});
+
 /* Note: in TeX, \em is restricted to text mode. We extend it to math
  * This is the 'switch' variant of \emph, i.e:
  * `\emph{important text}`

--- a/src/core-definitions/styling.ts
+++ b/src/core-definitions/styling.ts
@@ -561,6 +561,7 @@ defineFunction('htmlData', '{data:string}{content:auto}', {
     }),
 });
 
+/* assign CSS styles to the element */
 defineFunction('htmlStyle', '{data:string}{content:auto}', {
   createAtom: (command: string, args: Argument[], style: PrivateStyle): Atom =>
     new GroupAtom(args[1] as Atom[], {

--- a/src/core/box.ts
+++ b/src/core/box.ts
@@ -216,6 +216,7 @@ export class Box {
 
   cssId?: string;
   htmlData?: string;
+  htmlStyle?: string;
 
   svgBody?: string;
   svgOverlay?: string;
@@ -570,6 +571,7 @@ export class Box {
       classList.length > 0 ||
       this.cssId ||
       this.htmlData ||
+      this.htmlStyle ||
       this.attributes ||
       this.cssProperties ||
       this.svgBody ||
@@ -581,7 +583,6 @@ export class Box {
         // A (HTML5) CSS id may not contain a space
         props += ` id=${this.cssId.replace(/ /g, '-')} `;
       }
-
       if (this.htmlData) {
         const entries = this.htmlData.split(',');
         for (const entry of entries) {
@@ -597,6 +598,22 @@ export class Box {
               props += ` data-${key} `;
             }
           }
+        }
+      }
+      if (this.htmlStyle) {
+        const entries = this.htmlStyle.split(';');
+        let styleString = '';
+        for (const entry of entries) {
+          const matched = entry.match(/([^=]+):(.+$)/);
+          if (matched) {
+            const key = matched[1].trim().replace(/ /g, '-');
+            if (key) {
+              styleString += `${key}:${matched[2]};`;
+            }
+          }
+        }
+        if (styleString) {
+          props += ` style="${styleString}"`;
         }
       }
 

--- a/src/core/mathfield-box.ts
+++ b/src/core/mathfield-box.ts
@@ -51,6 +51,23 @@ export class MathfieldBox extends Box {
       }
     }
 
+    if (this.htmlStyle) {
+      const entries = this.htmlStyle.split(';');
+      let styleString = '';
+      for (const entry of entries) {
+        const matched = entry.match(/([^=]+):(.+$)/);
+        if (matched) {
+          const key = matched[1].trim().replace(/ /g, '-');
+          if (key) {
+            styleString += `${key}:${matched[2]};`;
+          }
+        }
+      }
+      if (styleString) {
+        props += ` style="${styleString}"`;
+      }
+    }
+
     if (this.attributes) {
       props +=
         ' ' +


### PR DESCRIPTION
HTML styling is supported in Katex and I think this will be a good idea to be supported here too. [Refrence](https://katex.org/docs/supported.html#html).

I made the necessary changes and tested them.

Thanks.