### PR TITLE
fix: properly observe changes to the `read-only` attribute

### DIFF
--- a/src/public/mathfield-element.ts
+++ b/src/public/mathfield-element.ts
@@ -603,6 +603,7 @@ export class MathfieldElement extends HTMLElement implements Mathfield {
       ...Object.keys(MathfieldElement.optionsAttributes),
       'disabled', // Global attribute
       'readonly', // A semi-global attribute (not all standard elements support it, but some do)
+      'read-only',
     ];
   }
 
@@ -1336,6 +1337,7 @@ export class MathfieldElement extends HTMLElement implements Mathfield {
       case 'disabled':
         this.disabled = hasValue;
         break;
+      case 'read-only':
       case 'readonly':
         this.readOnly = hasValue;
         break;


### PR DESCRIPTION
Before, changes to the `readonly` attribute were observed but changes to `read-only` were not. This was causing wrong behaviors when adding `read-only` to a `math-field` element, for example it was allowing users to modify the content of a `math-field` after adding the `read-only` attribute programmatically.
You can see here the behavior of a `math-field` after toggling `read-only` or `readonly`:
https://codepen.io/LuisMesa/pen/GROgOZz?editors=1010


https://user-images.githubusercontent.com/14155607/151276682-6043e35e-c2ef-4f88-a975-c75746211bec.mov


This is a related issue I just created: https://github.com/arnog/mathlive/issues/1319
This PR will prevent users from typing in the `math-field` after `read-only` was added.