### PR TITLE
core-definitions: fix \ne \neq rendering issue

### DIFF
--- a/src/core-atoms/group.ts
+++ b/src/core-atoms/group.ts
@@ -30,6 +30,7 @@ export class GroupAtom extends Atom {
       style?: Style;
       captureSelection?: boolean;
       serialize?: (atom: GroupAtom, options: ToLatexOptions) => string;
+      command?: string;
     }
   ) {
     super('group', {

--- a/src/core-definitions/definitions-utils.ts
+++ b/src/core-definitions/definitions-utils.ts
@@ -1138,6 +1138,7 @@ export function defineFunction(
       args: (null | Argument)[],
       options: ApplyStyleDefinitionOptions
     ) => PrivateStyle;
+    command?: string,
   }
 ): void {
   if (!options) options = {};

--- a/src/core-definitions/styling.ts
+++ b/src/core-definitions/styling.ts
@@ -993,7 +993,7 @@ defineFunction(['ne', 'neq'], '', {
         }),
         new Atom('mrel', { style, value: '=' }),
       ],
-      { boxType: 'mrel', captureSelection: true, serialize: () => name }
+      { boxType: 'mrel', captureSelection: true, serialize: () => name, command: name }
     ),
 });
 


### PR DESCRIPTION
fix `\ne` `\neq` disappearing operator bug documented in issue #1024

`\ne` and `\neq` operators' `createAtom` function is returning a `GroupAtom` class instance with an empty command value.
This causes `Parser`'s `parseCommand` method to populate `verbatimLatex` value with an empty string.
The empty `verbatimLatex` value causes a malfunction in `Atom`'s static `serialize` method removing `\neq` and `\ne` operators from displayed latex.