### PR TITLE
fix: Fixed #1366 by removing stop propagation 

### DIFF
--- a/src/editor-mathfield/pointer-input.ts
+++ b/src/editor-mathfield/pointer-input.ts
@@ -13,6 +13,10 @@ function isTouchEvent(evt: Event): evt is TouchEvent {
   return globalThis.TouchEvent !== undefined && evt instanceof TouchEvent;
 }
 
+function isPointerEvent(evt: Event): evt is PointerEvent {
+  return globalThis.PointerEvent !== undefined && evt instanceof PointerEvent;
+}
+
 export function onPointerDown(
   mathfield: MathfieldPrivate,
   evt: PointerEvent | TouchEvent
@@ -31,7 +35,7 @@ export function onPointerDown(
   // PointerEvent) the touchstart event is sent with event.buttons = 0
   // which for a mouse event would normally be an invalid button.
   // Accept this button 0.
-  if (evt instanceof PointerEvent && evt.buttons !== 1 && evt.buttons !== 0) {
+  if (isPointerEvent(evt) && evt.buttons > 1) {
     return;
   }
 
@@ -102,7 +106,7 @@ export function onPointerDown(
     scrollRight = x > fieldBounds.right;
     scrollLeft = x < fieldBounds.left;
     let actualAnchor: Offset = anchor;
-    if (evt instanceof PointerEvent) {
+    if (isPointerEvent(evt)) {
       if (!evt.isPrimary) {
         actualAnchor = offsetFromPoint(that, evt.clientX, evt.clientY, {
           bias: 0,

--- a/src/editor-mathfield/pointer-input.ts
+++ b/src/editor-mathfield/pointer-input.ts
@@ -72,7 +72,6 @@ export function onPointerDown(
     mathfield.element!.classList.remove('tracking');
     if (evt) {
       evt.preventDefault();
-      evt.stopPropagation();
     }
   }
 


### PR DESCRIPTION
closes #1366
Also prevent throw if `PointerEvent` is not supported / doesn't exist in a browser.