### PR TITLE
fix: add appropriate gap to aligned environment

### DIFF
--- a/src/core-definitions/environments.ts
+++ b/src/core-definitions/environments.ts
@@ -213,14 +213,14 @@ defineTabularEnvironment(
     const colFormat: ColumnFormat[] = [
       { gap: 0 },
       { align: 'r' },
-      { gap: 0 },
+      { gap: 0.25 },
       { align: 'l' },
     ];
     let i = 2;
     while (i < colCount) {
       colFormat.push({ gap: 1 });
       colFormat.push({ align: 'r' });
-      colFormat.push({ gap: 0 });
+      colFormat.push({ gap: 0.25 });
       colFormat.push({ align: 'l' });
       i += 2;
     }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/12475567/158049008-debd5756-a81b-49cc-9c6a-9976242e80a4.png)

After:
![image](https://user-images.githubusercontent.com/12475567/158049029-d68cc189-bd7e-4f91-8fe5-24195ba119c1.png)

LaTeX: `\begin{aligned}x^2 & =12 \\ x & =\sqrt{12}\end{aligned}`