### PR TITLE
fix: Fixed #1362 and #726

### DIFF
--- a/src/editor/shortcuts.ts
+++ b/src/editor/shortcuts.ts
@@ -15,12 +15,9 @@ export function getInlineShortcutsStartingWith(
 ): string[] {
   const result: string[] = [];
 
-  for (let i = 0; i <= s.length - 1; i++) {
-    const s2 = s.slice(Math.max(0, i));
-    for (const key of Object.keys(config.inlineShortcuts)) {
-      if (key.startsWith(s2) && !result.includes(key)) {
-        result.push(key!);
-      }
+  for (const key of Object.keys(config.inlineShortcuts)) {
+    if (key.startsWith(s)) {
+      result.push(key!);
     }
   }
 


### PR DESCRIPTION
I think this is an appropriate fix for these issues. I don't think it breaks anything else.

- `sin` -> `sinh` still works
- `xx` followed by 1 more `x` displays `×x` instead of `x×`
- all combinations of `>` and `=` and backspacing act as expected

Let me know if I missed anything.

closes #726
closes #759
closes #1362