### PR TITLE
fix: custom macro do not work when executeCommand insert or MathfieldElement setValue

### DIFF
--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -604,6 +604,8 @@ export class MathfieldPrivate implements Mathfield {
         this.options.onMoveOutOf(this, direction),
       tabOut: (_sender, direction) => this.options.onTabOutOf(this, direction),
     });
+    this.model.options.macros = this.options
+      .macros as NormalizedMacroDictionary;
 
     if (!this.options.locale.startsWith(getActiveKeyboardLayout().locale)) {
       setKeyboardLayoutLocale(this.options.locale);

--- a/src/editor-mathfield/mode-editor-math.ts
+++ b/src/editor-mathfield/mode-editor-math.ts
@@ -392,7 +392,7 @@ function convertStringToAtoms(
     result = parseLatex(s, {
       parseMode: 'math',
       args: args,
-      macros: options.macros,
+      macros: { ...model.options.macros, ...(options.macros ?? {}) },
       smartFence: options.smartFence,
       onError: model.listeners.onError,
       colorMap: options.colorMap,


### PR DESCRIPTION
I submitted PR for the first time. I'm very sorry for some problems in the format.

I use mathlive in my project. I defined a macro `OR`. When I execute the code `mf.executeCommand(['insert', '\\OR'])`, I find that mathlive can't render this macro accurately. When I execute code `mf.setValue('\\OR')`, the same result occurred. I read mathlive and found some problems, then fixed them. The following is my test code, which comes from `examples/basic/index.html`

```html
<!DOCTYPE html>
<html lang="en-US">
  <head>
    <meta charset="utf-8" />
    <title>MathLive Basic Example</title>
    <style>
      body {
        color: #444;
        background-color: #f9f9f9;
      }

      main {
        max-width: 820px;
        margin: auto;
      }

      math-field {
        border: 1px solid #ddd;
        padding: 5px;
        margin: 10px 0 10px 0;
        border-radius: 5px;
        background-color: #fff;
      }

      #output {
        padding: 5px;
        border-radius: 5px;
        border: 1px solid #000;

        color: #ddd;
        background: #35434e;

        font-family: monospace;
      }
    </style>
  </head>

  <body>
    <main>
      <h2>MathLive Basic Example</h2>
      <math-field id="mf">\OR a</math-field>
      <div id="output"></div>
      <button id="insertOr">插入命令</button>
      <button id="setValue">设置值</button>
      <button id="rerender">重新渲染</button>
    </main>

    <script type="module">
      import '/dist/mathlive.mjs';
      const mf = document.getElementById('mf');
      const insertOr = document.getElementById('insertOr');
      const rerender = document.getElementById('rerender');
      const setValue = document.getElementById('setValue');

      export const macros = {
        AND: '\\hspace{3}and\\hspace{3}',
        OR: '\\hspace{3}or\\hspace{3}',
      };

      mf.setOptions({
        macros: {
          ...macros,
        },
      });

      insertOr.addEventListener('click', () => {
        mf.executeCommand(['insert', '\\OR']);
      });

      setValue.addEventListener('click', () => {
        mf.setValue('\\OR');
      });

      mf.addEventListener('input', (ev) => {
        document.getElementById('output').innerHTML = ev.target.getValue();
        console.log(ev.target.getValue(), ev.target.getValue('latex-expanded'));
      });

      rerender.addEventListener('click', () => {
        mf.setOptions({
          macros: {
            ...mf.getOptions('macros'),
            ...macros,
          },
        });
      });
    </script>
  </body>
</html>

```