### PR TITLE
Group atoms inside of parentheses as implicit args (#1415)

### DIFF
--- a/src/core/delimiters.ts
+++ b/src/core/delimiters.ts
@@ -54,6 +54,12 @@ export const RIGHT_DELIM = {
   '\\lmoustache': '\\rmoustache',
 };
 
+export const LEFT_DELIM =
+  Object.fromEntries(
+    Object.entries(RIGHT_DELIM)
+      .map(([leftDelim, rightDelim]) => [rightDelim, leftDelim])
+  );
+
 function getSymbolValue(symbol: string): number {
   return (
     {


### PR DESCRIPTION
# What
This fixes #1415 and keeps the contents of parentheses together when you press the division key.

Behavior in a few cases can be seen here:
https://user-images.githubusercontent.com/446007/162076602-12b883c3-6093-4d42-95b0-9adae3c92b5d.mp4

 # How
When calculating what the "implicit argument" to division is, we follow this algorithm:

1. Consume atoms until you hit some sort of binary operator OR until you hit a closing delimiter.
2. If you hit a closing delimiter, consume atoms until that delimiter has been closed.

We keep track of which delimiters we've seen so far so that nested delimiters work correctly.

# Notes
If the closing delimiter is not matched up, we consider the entire preceding expression part of the implicit argument. There may be better behavior here -- thoughts, @arnog?

We look for exact matches of delimiters, not visual matches. So, an expression like `1 + \left(x)` might _look_ like it should consider `\left(x)` as the implicit argument, but it will actually treat the whole thing as the implicit argument since the right parenthesis is never matched. @arnog -- do you have a dictionary of "visually similar" delimiters yet, akin to `RIGHT_DELIM` but more general?