### PR TITLE
fix: typo in auto-render.ts

### DIFF
--- a/src/addons/auto-render.ts
+++ b/src/addons/auto-render.ts
@@ -618,10 +618,10 @@ function scanElement(element, options: AutoRenderOptionsPrivate): void {
       ) {
         let style = 'displaystyle';
         for (const l of childNode.type.split(';')) {
-          const v = l.split('=');
+          const v: string[] = l.split('=');
           if (v[0].toLowerCase() === 'mode') {
             style =
-              v[1].toLoweCase() === 'display' ? 'displaystyle' : 'textstyle';
+              v[1].toLowerCase() === 'display' ? 'displaystyle' : 'textstyle';
           }
         }
 


### PR DESCRIPTION
fix typo in code

static math expressions not rendering inline (textstyle) when latex code is wrapped inside `<script type='math/tex; mode=text'>` . The issue is the result of a minor typo in code which this Pull Request aims to fix