### PR TITLE
Allow options changes to visible virtual keyboards

### DIFF
--- a/src/editor/virtual-keyboard-commands.ts
+++ b/src/editor/virtual-keyboard-commands.ts
@@ -6,6 +6,7 @@ import {
   showAlternateKeys,
   hideAlternateKeys,
   VirtualKeyboard,
+  VirtualKeyboardTheme,
 } from './virtual-keyboard-utils';
 import { register as registerCommand, SelectorPrivate } from './commands';
 export { unshiftKeyboardLayer };
@@ -194,7 +195,7 @@ registerCommand(
 
 export function showVirtualKeyboard(
   keyboard: VirtualKeyboard,
-  theme: 'apple' | 'material' | '' = ''
+  theme: VirtualKeyboardTheme = ''
 ): boolean {
   keyboard.visible = false;
   toggleVirtualKeyboard(keyboard, theme);
@@ -209,7 +210,7 @@ export function hideVirtualKeyboard(keyboard: VirtualKeyboard): boolean {
 
 function toggleVirtualKeyboard(
   keyboard: VirtualKeyboard,
-  theme?: 'apple' | 'material' | ''
+  theme?: VirtualKeyboardTheme
 ): boolean {
   if (!keyboard.options.virtualKeyboardContainer) return false;
 

--- a/src/editor/virtual-keyboard-commands.ts
+++ b/src/editor/virtual-keyboard-commands.ts
@@ -1,7 +1,6 @@
 import { isArray } from '../common/types';
 
 import {
-  makeKeyboardElement,
   unshiftKeyboardLayer,
   onUndoStateChanged,
   showAlternateKeys,
@@ -9,7 +8,6 @@ import {
   VirtualKeyboard,
 } from './virtual-keyboard-utils';
 import { register as registerCommand, SelectorPrivate } from './commands';
-import { on } from '../editor-mathfield/utils';
 export { unshiftKeyboardLayer };
 
 /*
@@ -219,15 +217,7 @@ function toggleVirtualKeyboard(
   if (keyboard.visible) {
     keyboard.focusMathfield();
     if (keyboard.element) keyboard.element.classList.add('is-visible');
-    else {
-      // Construct the virtual keyboard
-      keyboard.element = makeKeyboardElement(keyboard, theme ?? '');
-      // Let's make sure that tapping on the keyboard focuses the field
-      on(keyboard.element, 'touchstart:passive mousedown', () =>
-        keyboard.focusMathfield()
-      );
-      keyboard.options.virtualKeyboardContainer.appendChild(keyboard.element);
-    }
+    else keyboard.buildAndAttachElement(theme);
 
     // For the transition effect to work, the property has to be changed
     // after the insertion in the DOM. Use setTimeout

--- a/src/editor/virtual-keyboard-utils.ts
+++ b/src/editor/virtual-keyboard-utils.ts
@@ -36,6 +36,7 @@ import { isBrowser, throwIfNotInBrowser } from '../common/capabilities';
 import { hashCode } from '../common/hash-code';
 import { Selector } from '../public/commands';
 import { MathfieldPrivate } from './mathfield';
+import { on } from '../editor-mathfield/utils';
 
 let gScrim: Scrim | null = null;
 
@@ -233,6 +234,15 @@ export class VirtualKeyboard implements VirtualKeyboardInterface {
 
   get height(): number {
     return this.element?.offsetHeight ?? 0;
+  }
+
+  buildAndAttachElement(theme?: 'apple' | 'material' | ''): void {
+    this.element = makeKeyboardElement(this, theme ?? '');
+    on(this.element, 'touchstart:passive mousedown', () =>
+      this.focusMathfield()
+    );
+    this.options.virtualKeyboardContainer?.appendChild(this.element);
+    this.element.classList.add('is-visible');
   }
 
   handleEvent(evt: Event): void {

--- a/src/editor/virtual-keyboard-utils.ts
+++ b/src/editor/virtual-keyboard-utils.ts
@@ -212,10 +212,11 @@ export class VirtualKeyboard implements VirtualKeyboardInterface {
   }
 
   setOptions(options: VirtualKeyboardOptions & CoreOptions): void {
-    this.visible = false;
     this._element?.remove();
     this._element = undefined;
     this.options = options;
+
+    if (this.visible) this.buildAndAttachElement(options.virtualKeyboardTheme);
   }
 
   get element(): HTMLDivElement | undefined {

--- a/src/editor/virtual-keyboard-utils.ts
+++ b/src/editor/virtual-keyboard-utils.ts
@@ -191,6 +191,8 @@ export function hideAlternateKeys(): boolean {
   return false;
 }
 
+export type VirtualKeyboardTheme = 'apple' | 'material' | '';
+
 export class VirtualKeyboard implements VirtualKeyboardInterface {
   options: VirtualKeyboardOptions & CoreOptions;
   _visible: boolean;
@@ -237,7 +239,7 @@ export class VirtualKeyboard implements VirtualKeyboardInterface {
     return this.element?.offsetHeight ?? 0;
   }
 
-  buildAndAttachElement(theme?: 'apple' | 'material' | ''): void {
+  buildAndAttachElement(theme?: VirtualKeyboardTheme): void {
     this.element = makeKeyboardElement(this, theme ?? '');
     on(this.element, 'touchstart:passive mousedown', () =>
       this.focusMathfield()
@@ -1694,7 +1696,7 @@ function expandLayerMarkup(
  */
 export function makeKeyboardElement(
   keyboard: VirtualKeyboard,
-  theme: 'apple' | 'material' | ''
+  theme: VirtualKeyboardTheme
 ): HTMLDivElement {
   throwIfNotInBrowser();
 

--- a/src/public/commands.ts
+++ b/src/public/commands.ts
@@ -7,6 +7,7 @@ import type {
   Model,
   VirtualKeyboardInterface,
 } from './mathfield';
+import { VirtualKeyboardTheme } from '../editor/virtual-keyboard-utils';
 
 /**
  * How much of the formula should be spoken:
@@ -323,7 +324,7 @@ export interface Commands {
    */
   toggleVirtualKeyboard: (
     keyboard: VirtualKeyboardInterface,
-    theme: 'apple' | 'material' | ''
+    theme: VirtualKeyboardTheme
   ) => boolean;
   /**
    * @category Virtual Keyboard
@@ -334,7 +335,7 @@ export interface Commands {
    */
   showVirtualKeyboard: (
     keyboard: VirtualKeyboardInterface,
-    theme: 'apple' | 'material' | ''
+    theme: VirtualKeyboardTheme
   ) => boolean;
 }
 


### PR DESCRIPTION
Currently if options are set on a visible keyboard it is implicitly removed from the DOM and not re-shown.

This change instead rebuilds the keyboard to reflect the new options if it is visible.