### PR TITLE
Disable the keyboard when a field is blurred

### DIFF
--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -1333,6 +1333,8 @@ export class MathfieldPrivate implements Mathfield {
     if (/onfocus|manual/.test(this.options.virtualKeyboardMode))
       this.executeCommand('hideVirtualKeyboard');
 
+    this.virtualKeyboard?.disable();
+
     if (typeof this.options.onBlur === 'function') this.options.onBlur(this);
 
     requestUpdate(this);

--- a/src/editor/virtual-keyboard-commands.ts
+++ b/src/editor/virtual-keyboard-commands.ts
@@ -223,6 +223,16 @@ function toggleVirtualKeyboard(
   } else if (keyboard.element) {
     // Remove the element from the DOM
     keyboard.disable();
+    hideAlternateKeys();
+    keyboard.visible = false;
+
+    keyboard.coreStylesheet?.release();
+    keyboard.coreStylesheet = null;
+    keyboard.virtualKeyboardStylesheet?.release();
+    keyboard.virtualKeyboardStylesheet = null;
+
+    keyboard._element?.remove();
+    keyboard._element = undefined;
   }
 
   keyboard.stateChanged();

--- a/src/editor/virtual-keyboard-utils.ts
+++ b/src/editor/virtual-keyboard-utils.ts
@@ -374,16 +374,6 @@ export class VirtualKeyboard implements VirtualKeyboardInterface {
       window.removeEventListener('touchend', this);
       window.removeEventListener('touchcancel', this);
     }
-    hideAlternateKeys();
-    this.visible = false;
-
-    this.coreStylesheet?.release();
-    this.coreStylesheet = null;
-    this.virtualKeyboardStylesheet?.release();
-    this.virtualKeyboardStylesheet = null;
-
-    this._element?.remove();
-    this._element = undefined;
   }
 
   dispose(): void {}


### PR DESCRIPTION
The implementation of `disable` was implicitly removing the element altogether. This PR breaks out the destruction of the virtual keyboard element into the hiding itself.

This implicit hiding meant that a `disable` had been removed from `onBlur`, resulting in multiple fields receiving keyboard events. By decoupling the disabling from the hiding, we can now avoid that problem whilst still allowing the `off` keyboard mode to provide a persistent keyboard.