### PR TITLE
prevent fonts loading multiple times

### DIFF
--- a/src/core/fonts.ts
+++ b/src/core/fonts.ts
@@ -1,4 +1,4 @@
-import { isBrowser, supportLocalFontEnumeration } from '../common/capabilities';
+import { isBrowser } from '../common/capabilities';
 import { resolveRelativeUrl } from '../common/script-url';
 import { ErrorListener, MathfieldErrorCode } from '../public/core';
 
@@ -48,14 +48,11 @@ export async function loadFonts(
     ];
     let fontsLoaded = false;
 
-    if (supportLocalFontEnumeration()) {
-      try {
-        fontsLoaded = fontFamilies.every((x) =>
-          document.fonts.check('16px ' + x)
-        );
-      } catch {
-        fontsLoaded = false;
-      }
+    try {
+      const fontsInDocument = Array.from(document.fonts).map((f) => f.family);
+      fontsLoaded = fontFamilies.every((x) => fontsInDocument.includes(x));
+    } catch {
+      fontsLoaded = false;
     }
 
     if (fontsLoaded) return;


### PR DESCRIPTION
`isBrowser() && !/firefox|safari/i.test(navigator.userAgent);`
The above test for browser in `supportLocalFontEnumeration` method is failing as Chrome and Microsoft Edge also has the word "Safari" in navigator.userAgent

The failed condition forcing the fonts to load multiple times in all major browsers, and resulting in static math to flicker each time mathfield is focused and virtual keypad is toggled to `showVirtualKeyboard`

This Pull Request aims to add alternate approach to detect loaded fonts in browser, and is tested to be working on latest versions of Chrome, Firefox, Safari and Microsoft Edge

