### PR TITLE
Add/remove padding-bottom for virtualKeyboard using a regexp pattern

### DIFF
--- a/src/editor/virtual-keyboard-commands.ts
+++ b/src/editor/virtual-keyboard-commands.ts
@@ -6,6 +6,8 @@ import {
   showAlternateKeys,
   hideAlternateKeys,
   VirtualKeyboard,
+  addKeyboardPadding,
+  removeKeyboardPadding
 } from './virtual-keyboard-utils';
 import { register as registerCommand, SelectorPrivate } from './commands';
 import { VirtualKeyboardTheme } from '../public/options';
@@ -200,16 +202,12 @@ export function showVirtualKeyboard(
   else keyboard.buildAndAttachElement(theme);
 
   if (!keyboard.visible) {
-    const padding =
-      keyboard.options.virtualKeyboardContainer.style.paddingBottom;
-    keyboard.originalContainerBottomPadding = padding;
-    if (padding)
-      keyboard.options.virtualKeyboardContainer.style.paddingBottom = `calc(${padding} + var(--keyboard-height, 276px) - 1px)`;
-    else {
-      keyboard.options.virtualKeyboardContainer.style.paddingBottom =
-        'calc(var(--keyboard-height, 276px) - 1px)';
-    }
+    keyboard.options.virtualKeyboardContainer.style.paddingBottom =
+      addKeyboardPadding(
+        keyboard.options.virtualKeyboardContainer.style.paddingBottom
+      );
   }
+
   // For the transition effect to work, the property has to be changed
   // after the insertion in the DOM. Use setTimeout
   setTimeout(() => {
@@ -240,7 +238,9 @@ export function hideVirtualKeyboard(keyboard: VirtualKeyboard): boolean {
     keyboard._element = undefined;
 
     keyboard.options.virtualKeyboardContainer.style.paddingBottom =
-      keyboard.originalContainerBottomPadding;
+      removeKeyboardPadding(
+        keyboard.options.virtualKeyboardContainer.style.paddingBottom
+      );
   }
 
   keyboard.visible = false;

--- a/src/editor/virtual-keyboard-utils.ts
+++ b/src/editor/virtual-keyboard-utils.ts
@@ -193,7 +193,6 @@ export class VirtualKeyboard implements VirtualKeyboardInterface {
   options: CombinedVirtualKeyboardOptions;
   _visible: boolean;
   _element?: HTMLDivElement;
-  originalContainerBottomPadding: string;
   private readonly _mathfield?: MathfieldPrivate;
 
   coreStylesheet: Stylesheet | null;
@@ -205,7 +204,6 @@ export class VirtualKeyboard implements VirtualKeyboardInterface {
     this._mathfield = mathfield as MathfieldPrivate;
     this.coreStylesheet = null;
     this.virtualKeyboardStylesheet = null;
-    this.originalContainerBottomPadding = '';
   }
 
   setOptions(options: CombinedVirtualKeyboardOptions): void {
@@ -2181,4 +2179,27 @@ function jsonToCss(json): string {
       return `${k} {${jsonToCssProps(json[k])}}`;
     })
     .join('');
+}
+
+/*
+ * Add and remove extra padding for the virtual keyboard using a search pattern
+ */
+const paddingValue = 'calc(var(--keyboard-height, 276px) - 1px)';
+const searchPattern = paddingValue.replace(/\W/g, '\\$&');
+
+export function addKeyboardPadding(padding: string): string {
+  if (!padding) return paddingValue;
+  else if (new RegExp(searchPattern).test(padding)) return padding;
+
+  return `calc(${padding} + ${paddingValue})`;
+}
+
+export function removeKeyboardPadding(padding: string): string {
+  if (!new RegExp(searchPattern).test(padding)) return padding;
+  else if (padding === paddingValue) return '';
+
+  return padding.replace(
+    new RegExp(`calc\\((.+) \\+ ${searchPattern}\\)`),
+    '$1'
+  );
 }


### PR DESCRIPTION
tested with empty initial `padding-bottom` and `padding-bottom:100px`

![padding](https://user-images.githubusercontent.com/2843147/176969386-d8333ee0-f828-46b8-af0c-caa62e8b57e3.gif)
