### PR TITLE
Scale fix for living in a transform-scaled environment

### DIFF
--- a/src/editor-mathfield/pointer-input.ts
+++ b/src/editor-mathfield/pointer-input.ts
@@ -126,8 +126,8 @@ export function onPointerDown(
     }
 
     // ts test
-    actualAnchor /= 2;
-    focus /= 2;
+    // actualAnchor /= 2;
+    // focus /= 2;
     // end ts test
 
     if (actualAnchor >= 0 && focus >= 0) {

--- a/src/editor-mathfield/pointer-input.ts
+++ b/src/editor-mathfield/pointer-input.ts
@@ -118,12 +118,17 @@ export function onPointerDown(
       );
     }
 
-    const focus = offsetFromPoint(that, x, y, {
+    let focus = offsetFromPoint(that, x, y, {
       bias: x <= anchorX ? (x === anchorX ? 0 : -1) : +1,
     });
     if (trackingWords) {
       // @todo: extend focus, actualAnchor to word boundary
     }
+
+    // ts test
+    actualAnchor /= 2;
+    focus /= 2;
+    // end ts test
 
     if (actualAnchor >= 0 && focus >= 0) {
       that.model.extendSelectionTo(actualAnchor, focus);

--- a/src/editor-mathfield/pointer-input.ts
+++ b/src/editor-mathfield/pointer-input.ts
@@ -118,17 +118,12 @@ export function onPointerDown(
       );
     }
 
-    let focus = offsetFromPoint(that, x, y, {
+    const focus = offsetFromPoint(that, x, y, {
       bias: x <= anchorX ? (x === anchorX ? 0 : -1) : +1,
     });
     if (trackingWords) {
       // @todo: extend focus, actualAnchor to word boundary
     }
-
-    // ts test
-    // actualAnchor /= 2;
-    // focus /= 2;
-    // end ts test
 
     if (actualAnchor >= 0 && focus >= 0) {
       that.model.extendSelectionTo(actualAnchor, focus);

--- a/src/editor-mathfield/render.ts
+++ b/src/editor-mathfield/render.ts
@@ -207,6 +207,19 @@ export function renderSelection(mathfield: MathfieldPrivate): void {
 
   const model = mathfield.model;
 
+  // Logic to accommodate mathfield hosted in an isotropically scale-transformed element.
+  // Without this, the selection indicator will not be in the right place.
+  // 1. Inquire how big the mathfield thinks it is
+  let supposedWidthStr = getComputedStyle(mathfield.field).width;
+  // 2. Take off the "px" and convert to number
+  supposedWidthStr = supposedWidthStr.substring(0, supposedWidthStr.length - 2);
+  const supposedWidth = Number(supposedWidthStr);
+  // 3. Get the actual screen width of the box
+  const actualWidth = mathfield.field.getBoundingClientRect().width;
+  // 4. Divide the two to get the scale factor
+  let scaleFactor = actualWidth / supposedWidth;
+  scaleFactor = isNaN(scaleFactor) ? 1 : scaleFactor;
+
   if (model.selectionIsCollapsed) {
     //
     // 1.1. Display the popover relative to the location of the caret
@@ -225,7 +238,13 @@ export function renderSelection(mathfield: MathfieldPrivate): void {
         mathfield,
         getAtomBounds(mathfield, atom)
       );
+
       if (bounds) {
+        bounds.left /= scaleFactor;
+        bounds.right /= scaleFactor;
+        bounds.top /= scaleFactor;
+        bounds.bottom /= scaleFactor;
+
         const element = document.createElement('div');
         element.classList.add('ML__contains-highlight');
         element.style.position = 'absolute';
@@ -247,6 +266,11 @@ export function renderSelection(mathfield: MathfieldPrivate): void {
   for (const x of unionRects(
     getSelectionBounds(mathfield, { excludeAtomsWithBackground: true })
   )) {
+    x.left /= scaleFactor;
+    x.right /= scaleFactor;
+    x.top /= scaleFactor;
+    x.bottom /= scaleFactor;
+
     const selectionElement = document.createElement('div');
     selectionElement.classList.add('ML__selection');
     selectionElement.style.position = 'absolute';


### PR DESCRIPTION
This is a tiny bit of code to make sure the selection is properly painted in an environment where a parent of MathfieldElement might have been scaled. In such environments, clientX/clientY/getBoundingClientRect() data cannot be used to construct coordinates to place new elements. Althought we cannot use getComputedStyle() to find the parent transform, we can compare sizes:

The fix calculates the ratio of the "supposed" width of the mathfield (from getComputedStyle) compared to the actual (client) width, and calculates the applied scaleFactor. Later, selection box coordinates are divided by the scaleFactor for both the collapsed and uncollapsed cases. 