### PR TITLE
fix for issue 1605

### DIFF
--- a/src/editor-mathfield/pointer-input.ts
+++ b/src/editor-mathfield/pointer-input.ts
@@ -286,7 +286,9 @@ function nearestAtomFromPointRecursive(
   if (!bounds) return [Infinity, null];
 
   let result: [distance: number, atom: Atom | null] = [
-    atom.type === 'group' ? Infinity : distance(x, y, bounds),
+    atom.type === 'group' || atom.type === 'root'
+      ? Infinity
+      : distance(x, y, bounds),
     atom,
   ];
   //


### PR DESCRIPTION
See issue for problem description. The problem is that nearestAtomFromPointRecursive initializes the result incorrectly, and children are not considered as closer candidates if the group is a "root". The fix is to broaden the criterion for special initialization from "group" only to "group" or "root".