### PR TITLE
fix: hide keyboard if `readonly` is added while `virtualKeyboardMode` is `off`

### DIFF
--- a/src/public/mathfield-element.ts
+++ b/src/public/mathfield-element.ts
@@ -1183,6 +1183,9 @@ export class MathfieldElement extends HTMLElement implements Mathfield {
         break;
       case 'read-only':
       case 'readonly':
+        if (this._mathfield?.virtualKeyboardState === 'visible')
+          this._mathfield?.executeCommand('hideVirtualKeyboard');
+
         this.readOnly = hasValue;
         break;
       default:


### PR DESCRIPTION
Before, an input that was just transformed into a readonly input could have its keyboard open if `virtualKeyboardMode` is `off`. Also, any attempt to close it using the `hideVirtualKeyboard` command would be ignored because this [check](https://github.com/arnog/mathlive/blob/507c7d833c3abdb4f83786735b357e4b47d02d1c/src/editor-mathfield/mathfield-private.ts#L633) related to `readonly` would prevent it. To fix this, we should close the keyboard if the input becomes a readonly input and if it was open.

You can see the faulty behavior in [this](https://codepen.io/LuisMesa/pen/WNJNXVB) Codepen.

Below you can see how the keyboard remains open:

https://user-images.githubusercontent.com/14155607/188730446-51237bd2-c381-4c8d-b00c-3e52bc07ef67.mov


