### PR TITLE
Better vertical navigation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,5 +36,6 @@
   "eslint.alwaysShowStatus": true,
   "eslint.format.enable": true,
   "eslint.lintTask.enable": true,
-  "cSpell.language": "en,en-US"
+  "cSpell.language": "en,en-US",
+  "editor.tabSize": 2
 }

--- a/src/core/atom-class.ts
+++ b/src/core/atom-class.ts
@@ -890,7 +890,7 @@ export class Atom {
   }
 
   get hasChildren(): boolean {
-    return this._branches && this.children.length > 0;
+    return Boolean(this._branches && this.children.length > 0);
   }
 
   get firstChild(): Atom {

--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -1508,4 +1508,18 @@ export class MathfieldPrivate implements GlobalContext, Mathfield {
     ev.preventDefault();
     ev.stopPropagation();
   }
+
+  getHTMLElement(atom: Atom): HTMLSpanElement {
+    // find an atom id in this atom or its children
+    let target = atom;
+    while (!target.id && target.hasChildren) {
+      target = atom.children[0];
+    }
+    if (target.id) {
+      return this.element!.querySelector(
+        `[data-atom-id="${target.id}"]`
+      ) as HTMLSpanElement;
+    }
+    throw new TypeError('Could not get an ID from atom');
+  }
 }

--- a/src/editor-mathfield/utils.ts
+++ b/src/editor-mathfield/utils.ts
@@ -255,3 +255,21 @@ export function validateOrigin(
 
   return false;
 }
+
+/**
+ * Calculates a DOMRect like getBoundingClientRect
+ * but excluding any CSS transforms
+ */
+export function getLocalDOMRect(el: HTMLElement): DOMRect {
+  let offsetTop = 0;
+  let offsetLeft = 0;
+  const width = el.offsetWidth;
+  const height = el.offsetHeight;
+  while (el instanceof HTMLElement) {
+    offsetTop += el.offsetTop;
+    offsetLeft += el.offsetLeft;
+    el = el.offsetParent as HTMLElement;
+  }
+
+  return new DOMRect(offsetLeft, offsetTop, width, height);
+}

--- a/src/editor-model/commands.ts
+++ b/src/editor-model/commands.ts
@@ -401,7 +401,7 @@ function getClosestAtomToXPosition(
   mathfield: MathfieldPrivate,
   search: Atom[],
   x: number
-) {
+): Atom {
   let prevX = Infinity;
   let i = 0;
   for (; i < search.length; i++) {
@@ -409,7 +409,7 @@ function getClosestAtomToXPosition(
     const abs = Math.abs(x - toX);
 
     if (abs <= prevX) {
-      // minimise distance to fromX
+      // minimise distance to x
       prevX = abs;
     } else {
       // this element is further away

--- a/src/editor-model/commands.ts
+++ b/src/editor-model/commands.ts
@@ -1,4 +1,5 @@
 import type { ModelPrivate } from './model-private';
+import { MathfieldPrivate, getLocalDOMRect } from 'editor/mathfield';
 import { Atom } from '../core/atom-class';
 import { ArrayAtom } from '../core-atoms/array';
 import { LatexAtom } from '../core-atoms/latex';
@@ -396,33 +397,15 @@ function setPositionHandlingPlaceholder(
   } else model.position = pos;
 }
 
-/**
- * Calculates a DOMRect like getBoundingClientRect
- * but excluding any CSS transforms
- */
-function getLocalDOMRect(el: HTMLElement): DOMRect {
-  let offsetTop = 0;
-  let offsetLeft = 0;
-  const width = el.offsetWidth;
-  const height = el.offsetHeight;
-  while (el instanceof HTMLElement) {
-    offsetTop += el.offsetTop;
-    offsetLeft += el.offsetLeft;
-    el = el.offsetParent as HTMLElement;
-  }
-
-  return new DOMRect(offsetLeft, offsetTop, width, height);
-}
-
 function getClosestAtomToXPosition(
-  model: ModelPrivate,
+  mathfield: MathfieldPrivate,
   search: Atom[],
   x: number
 ) {
   let prevX = Infinity;
   let i = 0;
   for (; i < search.length; i++) {
-    const toX = getLocalDOMRect(model.getHTMLElement(search[i])).right;
+    const toX = getLocalDOMRect(mathfield.getHTMLElement(search[i])).right;
     const abs = Math.abs(x - toX);
 
     if (abs <= prevX) {
@@ -464,9 +447,11 @@ function moveUpward(
     const rowAbove = Math.max(0, atom.treeBranch[0] - 1);
     const aboveCell = arrayAtom.array[rowAbove][atom.treeBranch[1]]!;
     // calculate best atom to put cursor at based on real x coordinate
-    const fromX = getLocalDOMRect(model.getHTMLElement(baseAtom)).right;
+    const fromX = getLocalDOMRect(
+      model.mathfield.getHTMLElement(baseAtom)
+    ).right;
     const targetSelection = model.offsetOf(
-      getClosestAtomToXPosition(model, aboveCell, fromX)
+      getClosestAtomToXPosition(model.mathfield, aboveCell, fromX)
     );
 
     if (extend) {
@@ -563,9 +548,11 @@ function moveDownward(
     );
     const belowCell = arrayAtom.array[rowBelow][atom.treeBranch[1]]!;
     // calculate best atom to put cursor at based on real x coordinate
-    const fromX = getLocalDOMRect(model.getHTMLElement(baseAtom)).right;
+    const fromX = getLocalDOMRect(
+      model.mathfield.getHTMLElement(baseAtom)
+    ).right;
     const targetSelection = model.offsetOf(
-      getClosestAtomToXPosition(model, belowCell, fromX)
+      getClosestAtomToXPosition(model.mathfield, belowCell, fromX)
     );
 
     if (extend) {

--- a/src/editor-model/model-private.ts
+++ b/src/editor-model/model-private.ts
@@ -239,6 +239,20 @@ export class ModelPrivate implements Model {
     return this.atoms.indexOf(atom);
   }
 
+  getHTMLElement(atom: Atom): HTMLSpanElement {
+    // find an atom id in this atom or its children
+    let target = atom;
+    while (!target.id && target.hasChildren) {
+      target = atom.children[0];
+    }
+    if (target.id) {
+      return this.mathfield.element!.querySelector(
+        `[data-atom-id="${target.id}"]`
+      ) as HTMLSpanElement;
+    }
+    throw new TypeError('Could not get an ID from atom');
+  }
+
   getSiblingsRange(offset: Offset): Range {
     const atom: Atom = this.at(offset);
     const { parent } = atom;

--- a/src/editor-model/model-private.ts
+++ b/src/editor-model/model-private.ts
@@ -239,20 +239,6 @@ export class ModelPrivate implements Model {
     return this.atoms.indexOf(atom);
   }
 
-  getHTMLElement(atom: Atom): HTMLSpanElement {
-    // find an atom id in this atom or its children
-    let target = atom;
-    while (!target.id && target.hasChildren) {
-      target = atom.children[0];
-    }
-    if (target.id) {
-      return this.mathfield.element!.querySelector(
-        `[data-atom-id="${target.id}"]`
-      ) as HTMLSpanElement;
-    }
-    throw new TypeError('Could not get an ID from atom');
-  }
-
   getSiblingsRange(offset: Offset): Range {
     const atom: Atom = this.at(offset);
     const { parent } = atom;


### PR DESCRIPTION
I made it measure pixels and compare to the (base) elements of the upper or lower matrix cell. The way I get the DOM elements feels hacky.

LaTeX I used to test:
```
\begin{align}b+c+d+e & =f \\ a+\sqrt{a^2+b^2}+b & =g\end{align}
```

You can go from in the middle of the sqrt to the same (closest) position above. It doesn't work in reverse - not sure if that is desired?

Also this logic could probably be applied to moving between fraction upper and lower, but I haven't spent the time to look for where the code is for that.

I also made sure it works when the element is rotated by CSS.