### PR TITLE
feat: add matrix remove row/column keyboard shortcuts

### DIFF
--- a/src/core-atoms/array.ts
+++ b/src/core-atoms/array.ts
@@ -662,6 +662,35 @@ export class ArrayAtom extends Atom {
     this.isDirty = true;
   }
 
+  removeRow(row: number): void {
+    console.assert(
+      this.type === 'array' && Array.isArray(this.array) && this.rowCount > row
+    );
+
+    const deleted = this.array.splice(row, 1);
+    for (const column of deleted) {
+      for (const cell of column) {
+        if (cell) {
+          for (const child of cell) {
+            child.parent = undefined;
+            child.treeBranch = undefined;
+          }
+        }
+      }
+    }
+    for (let i = row; i < this.rowCount; i++) {
+      for (let j = 0; j < this.colCount; j++) {
+        const atoms = this.array[i][j];
+        if (atoms) {
+          for (const atom of atoms) {
+            atom.treeBranch = [i, j];
+          }
+        }
+      }
+    }
+    this.isDirty = true;
+  }
+
   addColumnBefore(col: number): void {
     console.assert(this.type === 'array' && Array.isArray(this.array));
     for (const row of this.array) {
@@ -687,6 +716,34 @@ export class ArrayAtom extends Atom {
     }
     for (let i = 0; i < this.rowCount; i++) {
       for (let j = col + 1; j < this.colCount; j++) {
+        const atoms = this.array[i][j];
+        if (atoms) {
+          for (const atom of atoms) {
+            atom.treeBranch = [i, j];
+          }
+        }
+      }
+    }
+    this.isDirty = true;
+  }
+
+  removeColumn(col: number): void {
+    console.assert(
+      this.type === 'array' && Array.isArray(this.array) && this.colCount > col
+    );
+    for (const row of this.array) {
+      const deleted = row.splice(col, 1);
+      for (const cell of deleted) {
+        if (cell) {
+          for (const child of cell) {
+            child.parent = undefined;
+            child.treeBranch = undefined;
+          }
+        }
+      }
+    }
+    for (let i = 0; i < this.rowCount; i++) {
+      for (let j = col; j < this.colCount; j++) {
         const atoms = this.array[i][j];
         if (atoms) {
           for (const atom of atoms) {

--- a/src/editor-model/array.ts
+++ b/src/editor-model/array.ts
@@ -208,18 +208,22 @@ function removeCell(model: ModelPrivate, where: 'row' | 'column'): void {
       case 'row':
         if (arrayAtom.rowCount > 1) {
           arrayAtom.removeRow(treeBranch[0]);
-          pos = model.offsetOf(
-            arrayAtom.getCell(Math.max(0, treeBranch[0] - 1), treeBranch[1])![0]
-          );
+          const cell = arrayAtom.getCell(
+            Math.max(0, treeBranch[0] - 1),
+            treeBranch[1]
+          )!;
+          pos = model.offsetOf(cell[cell.length - 1]);
         }
         break;
 
       case 'column':
         if (arrayAtom.colCount > 1) {
           arrayAtom.removeColumn(treeBranch[1]);
-          pos = model.offsetOf(
-            arrayAtom.getCell(treeBranch[0], Math.max(0, treeBranch[1] - 1))![0]
-          );
+          const cell = arrayAtom.getCell(
+            treeBranch[0],
+            Math.max(0, treeBranch[1] - 1)
+          )!;
+          pos = model.offsetOf(cell[cell.length - 1]);
         }
         break;
     }

--- a/src/editor-model/commands.ts
+++ b/src/editor-model/commands.ts
@@ -377,24 +377,11 @@ export function move(
     //
     // 3. Handle placeholder
     //
-    setPositionHandlingPlaceholder(model, pos);
+    model.setPositionHandlingPlaceholder(pos);
   }
 
   model.announce('move', previousPosition);
   return true;
-}
-
-function setPositionHandlingPlaceholder(
-  model: ModelPrivate,
-  pos: Offset
-): void {
-  if (model.at(pos)?.type === 'placeholder') {
-    // We're going right of a placeholder: select it
-    model.setSelection(pos - 1, pos);
-  } else if (model.at(pos)?.rightSibling?.type === 'placeholder') {
-    // We're going left of a placeholder: select it
-    model.setSelection(pos, pos + 1);
-  } else model.position = pos;
 }
 
 function getClosestAtomToXPosition(
@@ -454,7 +441,7 @@ function moveToClosestAtomVertically(
     model.setSelection(newSelection);
   } else {
     // move cursor
-    setPositionHandlingPlaceholder(model, targetSelection);
+    model.setPositionHandlingPlaceholder(targetSelection);
   }
 
   model.announce(`move ${direction}`);

--- a/src/editor-model/model-private.ts
+++ b/src/editor-model/model-private.ts
@@ -153,6 +153,16 @@ export class ModelPrivate implements Model {
     });
   }
 
+  setPositionHandlingPlaceholder(pos: Offset): void {
+    if (this.at(pos)?.type === 'placeholder') {
+      // We're going right of a placeholder: select it
+      this.setSelection(pos - 1, pos);
+    } else if (this.at(pos)?.rightSibling?.type === 'placeholder') {
+      // We're going left of a placeholder: select it
+      this.setSelection(pos, pos + 1);
+    } else this.position = pos;
+  }
+
   getState(): ModelState {
     return {
       content: this.root.toJson(),

--- a/src/editor/keybindings-definitions.ts
+++ b/src/editor/keybindings-definitions.ts
@@ -349,6 +349,16 @@ export const DEFAULT_KEYBINDINGS: Keybinding[] = [
     ifMode: 'math',
     command: 'addRowBefore',
   },
+  {
+    key: 'ctrl+[Backspace]',
+    ifMode: 'math',
+    command: 'removeRow',
+  },
+  {
+    key: 'cmd+[Backspace]',
+    ifMode: 'math',
+    command: 'removeRow',
+  },
 
   {
     key: 'ctrl+[Comma]',
@@ -374,6 +384,12 @@ export const DEFAULT_KEYBINDINGS: Keybinding[] = [
     ifMode: 'math',
     command: 'addColumnBefore',
   },
+  {
+    key: 'shift+[Backspace]',
+    ifMode: 'math',
+    command: 'removeColumn',
+  },
+
   {
     key: 'alt+[Digit5]',
     ifLayout: ['apple.en-intl', 'windows.en-intl', 'linux.en'],

--- a/src/public/commands.ts
+++ b/src/public/commands.ts
@@ -150,6 +150,14 @@ export interface Commands {
    * @category Array
    */
   addColumnBefore: (model: Model) => boolean;
+  /**
+   * @category Array
+   */
+  removeRow: (model: Model) => boolean;
+  /**
+   * @category Array
+   */
+  removeColumn: (model: Model) => boolean;
 
   /**
    * @category Deleting


### PR DESCRIPTION
LaTeX to test:
```
\begin{bmatrix}a & b & c \\ d & e & f \\ g & h & i\end{bmatrix}
```
new hotkeys:
  | Key Binding                                                         | Command           |
  | :------------------------------------------------- | :----------------- |
  | <kbd>ctrl/⌘</kbd>+<kbd>[Backspace]</kbd> | `removeRow`       |
  | <kbd>shift</kbd>+<kbd>[Backspace]</kbd>   | `removeColumn`  |
