### PR TITLE
feat: allow pasting of multiple columns in environments

### DIFF
--- a/src/core-atoms/array.ts
+++ b/src/core-atoms/array.ts
@@ -620,9 +620,27 @@ export class ArrayAtom extends Atom {
     return this.array[row][col];
   }
 
-  setCell(_row: number, _column: number, _value: Atom[]): void {
-    // @todo array
-    console.assert(this.type === 'array' && Array.isArray(this.array));
+  setCell(row: number, column: number, value: Atom[]): void {
+    console.assert(
+      this.type === 'array' &&
+        Array.isArray(this.array) &&
+        this.array[row][column] !== undefined
+    );
+    for (const atom of this.array[row][column]!) {
+      atom.parent = undefined;
+      atom.treeBranch = undefined;
+    }
+
+    let atoms = value;
+    if (value.length === 0 || value[0].type !== 'first') {
+      atoms = [new Atom('first', this.context, { mode: this.mode }), ...value];
+    }
+
+    this.array[row][column] = atoms;
+    for (const atom of atoms) {
+      atom.parent = this;
+      atom.treeBranch = [row, column];
+    }
     this.isDirty = true;
   }
 
@@ -712,6 +730,10 @@ export class ArrayAtom extends Atom {
       }
     }
     this.isDirty = true;
+  }
+
+  addColumn(): void {
+    this.addColumnAfter(this.colCount - 1);
   }
 
   removeColumn(col: number): void {

--- a/src/core-atoms/array.ts
+++ b/src/core-atoms/array.ts
@@ -313,6 +313,10 @@ export class ArrayAtom extends Atom {
     return this.array[0].length;
   }
 
+  get maxColumns(): number {
+    return this.colFormat.filter((col) => Boolean(col['align'])).length;
+  }
+
   removeBranch(name: Branch): Atom[] {
     if (isNamedBranch(name)) return super.removeBranch(name);
 

--- a/src/editor-mathfield/mode-editor-math.ts
+++ b/src/editor-mathfield/mode-editor-math.ts
@@ -89,16 +89,27 @@ export class MathModeEditor extends ModeEditor {
             }
 
             // expand environment columns to paste size
-            const currentRow = Number(cursor.treeBranch![0]);
-            const currentColumn = Number(cursor.treeBranch![1]);
-            while (cursor.parent.colCount - currentColumn < columns.length)
+            let currentRow = Number(cursor.treeBranch![0]);
+            let currentColumn = Number(cursor.treeBranch![1]);
+            const maxColumns = cursor.parent.maxColumns;
+            while (
+              cursor.parent.colCount - currentColumn < columns.length &&
+              cursor.parent.colCount < maxColumns
+            )
               cursor.parent.addColumn();
 
             // add content to the first cell
             cursor.parent.addChildrenAfter(columns[0], cursor);
             // replace the rest of the columns
-            for (let i = 1; i < columns.length; i++)
-              cursor.parent.setCell(currentRow, currentColumn + i, columns[i]);
+            for (let i = 1; i < columns.length; i++) {
+              currentColumn++;
+              if (currentColumn >= maxColumns) {
+                currentColumn = 0;
+                cursor.parent.addRowAfter(currentRow);
+                currentRow++;
+              }
+              cursor.parent.setCell(currentRow, currentColumn, columns[i]);
+            }
           } else {
             cursor.parent!.addChildrenAfter(
               atoms.filter((a) => a.type !== 'first'),

--- a/src/editor-mathfield/mode-editor-math.ts
+++ b/src/editor-mathfield/mode-editor-math.ts
@@ -67,7 +67,45 @@ export class MathModeEditor extends ModeEditor {
           if (!model.selectionIsCollapsed)
             model.deleteAtoms(range(model.selection));
           const cursor = model.at(model.position);
-          cursor.parent!.addChildrenAfter(atoms, cursor);
+
+          if (cursor.parent instanceof ArrayAtom) {
+            console.assert(cursor.treeBranch !== undefined);
+            // use 'first' atoms as environment column delimiter
+            const columns: Atom[][] = [];
+            let buffer: Atom[] = [];
+            // trim 'first' from array of atoms
+            if (atoms[0].type === 'first') atoms.shift();
+            if (atoms[atoms.length - 1].type === 'first') atoms.pop();
+            for (const atom of atoms) {
+              if (atom.type === 'first' && buffer.length > 0) {
+                columns.push(buffer);
+                buffer = [atom];
+              } else {
+                buffer.push(atom);
+              }
+            }
+            if (buffer.length > 0) {
+              columns.push(buffer);
+            }
+
+            // expand environment columns to paste size
+            const currentRow = Number(cursor.treeBranch![0]);
+            const currentColumn = Number(cursor.treeBranch![1]);
+            while (cursor.parent.colCount - currentColumn < columns.length)
+              cursor.parent.addColumn();
+
+            // add content to the first cell
+            cursor.parent.addChildrenAfter(columns[0], cursor);
+            // replace the rest of the columns
+            for (let i = 1; i < columns.length; i++)
+              cursor.parent.setCell(currentRow, currentColumn + i, columns[i]);
+          } else {
+            cursor.parent!.addChildrenAfter(
+              atoms.filter((a) => a.type !== 'first'),
+              cursor
+            );
+          }
+
           model.position = model.offsetOf(atoms[atoms.length - 1]);
 
           contentDidChange(model, { inputType: 'insertFromPaste' });

--- a/src/editor-model/array.ts
+++ b/src/editor-model/array.ts
@@ -137,10 +137,7 @@ function addCell(
         break;
 
       case 'after column':
-        if (
-          arrayAtom.colFormat.filter((col) => Boolean(col['align'])).length <=
-          arrayAtom.colCount
-        ) {
+        if (arrayAtom.maxColumns <= arrayAtom.colCount) {
           model.announce('plonk');
           return;
         }
@@ -156,10 +153,7 @@ function addCell(
         break;
 
       case 'before column':
-        if (
-          arrayAtom.colFormat.filter((col) => Boolean(col['align'])).length <=
-          arrayAtom.colCount
-        ) {
+        if (arrayAtom.maxColumns <= arrayAtom.colCount) {
           model.announce('plonk');
           return;
         }


### PR DESCRIPTION
There is a preexisting bug where if you highlight the entire innards of the environment and paste it will paste outside - I'm not sure how to address this...

https://user-images.githubusercontent.com/12475567/196035430-52cc342b-7298-4939-b95f-994c21faf064.mp4

Also not sure how to handle multiple rows... at least it's a start.

Also fixed an issue when copying from multiple columns to outside an environment - it included the `first` elements which makes things weird when they aren't in the first position.