### PR TITLE
fix: remove extra complete call

### DIFF
--- a/src/editor/virtual-keyboard-commands.ts
+++ b/src/editor/virtual-keyboard-commands.ts
@@ -28,15 +28,6 @@ export function switchKeyboardLayer(
   keyboard: VirtualKeyboard,
   layer: string | null
 ): boolean {
-  if (
-    layer !== 'lower-command' &&
-    layer !== 'upper-command' &&
-    layer !== 'symbols-command'
-  ) {
-    // If we switch to a non-command keyboard layer, first exit command mode.
-    keyboard.executeCommand('complete');
-  }
-
   showVirtualKeyboard(keyboard);
   // If the alternate keys panel was visible, hide it
   hideAlternateKeys();


### PR DESCRIPTION
Closes #1783 

I couldn't find any references to `lower-command`, `upper-command`, `symbols-command` in the repo, and `complete` already gets executed in `mathfield-private.ts:1172`, so I'm not sure if this code is needed and it fixes the issue.

The issue being that because it's a remote keyboard anything going through `executeCommand` is delayed by 1 frame because it's handled by event listeners? So it was completing the inserted `\` one frame later.