### PR TITLE
fix: use cursor pointer on just the buttons of the virtual keyboard

### DIFF
--- a/css/virtual-keyboard.less
+++ b/css/virtual-keyboard.less
@@ -145,7 +145,14 @@
         background: transparent;
         border: 1px solid transparent; // #e5e6e9;
         border-radius: 5px;
+
         pointer-events: all;
+        cursor: pointer;
+
+        .ML__mathlive {
+          pointer-events: none;
+        }
+
         color: var(--keyboard-alternate-text);
         fill: currentColor;
         &:hover,

--- a/css/virtual-keyboard.less
+++ b/css/virtual-keyboard.less
@@ -447,6 +447,10 @@
 
           cursor: pointer;
 
+          .ML__mathlive {
+            pointer-events: none;
+          }
+
           /* Last key should be flush against the border */
           &:last-child {
             margin-right: 0;

--- a/css/virtual-keyboard.less
+++ b/css/virtual-keyboard.less
@@ -236,7 +236,6 @@
     touch-action: none;
     -webkit-user-select: none;
     user-select: none;
-    cursor: pointer;
 
     box-shadow: @shadow2;
 
@@ -445,6 +444,8 @@
           border: 1px solid var(--keycap-background-border);
           border-bottom-color: var(--keycap-background-border-bottom);
           border-radius: 5px;
+
+          cursor: pointer;
 
           /* Last key should be flush against the border */
           &:last-child {


### PR DESCRIPTION
The entire keyboard had `cursor: pointer` when it should just be the buttons you can click.