### PR TITLE
Gm test

### DIFF
--- a/src/editor-mathfield/mode-editor.ts
+++ b/src/editor-mathfield/mode-editor.ts
@@ -37,6 +37,9 @@ export class ModeEditor {
     mathfield: MathfieldPrivate,
     ev: ClipboardEvent
   ): boolean {
+    // if this is the redispatched (untrusted) event, ignore it but let it proceed
+    if (!ev.isTrusted) return true;
+
     const redispatchedEvent = new ClipboardEvent('paste', {
       clipboardData: ev.clipboardData,
       cancelable: true,


### PR DESCRIPTION
For your consideration, a first cut at fixing the touch-capable-device-with-hardware-keyboard cut/copy/past problem. Two problems:

- trap for keystrokes in keydown listener swallowed the keys. Now letting ctrl- and meta- keys through instead of routing keys to typedText() handler.
- contrary to spec, it seems that neither Safari nor Chrome generate a "paste" event on an element if that element does not have a content-editable standard element inside. It seems that your setting of contenteditable=true on the math-field is ignored by those browsers because it's not an element type known to the browser a priori (I am guessing here). Now, in absence of textarea, this PR is attaching listener to window, and preventing re-dispatching of event (to prevent infinite recursion). 

I noticed that you do some checks for inBrowser() at times, let me know if my use of window and document is not ok in the fix. 

BTW mf.executeCommand(["paste", <text>]) assumes a textarea underneath, but that's a separate problem that should enjoy a separate fix.