### PR TITLE
fix for ctrl x/c/v

### DIFF
--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -268,17 +268,10 @@ export class MathfieldPrivate implements GlobalContext, Mathfield {
     // They are retrieved in order a bit later, so they need to be kept in sync
 
     // 1/ The keyboard event capture element.
-    // On touch capable devices, we do not create a textarea to capture keyboard
-    // events as this has the side effect of triggering the OS virtual keyboard
-    // which we want to avoid
     let markup = '<span class=ML__textarea>';
-    if (isTouchCapable())
-      markup += `<span class=ML__textarea__textarea tabindex=-1 role=textbox></span>`;
-    else {
-      markup += `<textarea class=ML__textarea__textarea autocapitalize=off autocomplete=off autocorrect=off spellcheck=false inputmode=none aria-hidden="true" tabindex="${
-        element.tabIndex ?? 0
-      }"></textarea>`;
-    }
+    markup += `<textarea inputmode="none" class=ML__textarea__textarea autocapitalize=off autocomplete=off autocorrect=off spellcheck=false inputmode=none aria-hidden="true" tabindex="${
+      element.tabIndex ?? 0
+    }"></textarea>`;
     markup += '</span>';
 
     // 2/ The field, where the math equation will be displayed

--- a/src/editor/keyboard.ts
+++ b/src/editor/keyboard.ts
@@ -248,12 +248,6 @@ export function delegateKeyboardEvents(
       if (!handlers.keystroke(keyboardEventToString(event), event)) {
         keydownEvent = null;
         textarea.value = '';
-      } else if (textarea.tagName.toLowerCase() !== 'textarea') {
-        // If we did not create a text-area because we're on a mobile
-        // device and we don't want to use the OS virtual keyboard, capture
-        // the key events possibly coming from an attached hardware keyboard
-        if (event.key.length === 1) handlers.typedText(event.key);
-        event.preventDefault();
       }
     },
     true


### PR DESCRIPTION
trivial addition of inputtype="none" on textarea seems to successfully disable OS virtual keyboard, but otherwise stay functional. 