### PR TITLE
#1884 again

### DIFF
--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -1251,13 +1251,12 @@ export class MathfieldPrivate implements GlobalContext, Mathfield {
         return;
       }
 
-      const rightSibling = prompt?.rightSibling;
-      const promptFirstOffset = this.model.offsetOf(prompt) + 1;
-      const promptLastOffset = rightSibling
-        ? this.model.offsetOf(rightSibling) - 1
-        : this.model.lastOffset;
+      const branchRange = this.model.getBranchRange(
+        this.model.offsetOf(prompt),
+        'body'
+      );
 
-      this.model.setSelection(promptFirstOffset, promptLastOffset);
+      this.model.setSelection(branchRange);
       this.insert(value, { insertionMode: 'replaceSelection' });
     }
     requestUpdate(this);


### PR DESCRIPTION
Since prompt body is a branch, the offsets behave unexpectedly, souse `getBranchRange` instead.