### PR TITLE
Allow insertOptions in setPromptContent

### DIFF
--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -1247,7 +1247,7 @@ If you are using Vue, this may be because you are using the runtime-only build o
   setPromptValue(
     id: string,
     value?: string,
-    insertOptions?: InsertOptions
+    insertOptions?: Omit<InsertOptions, 'insertionMode'>
   ): void {
     if (value !== undefined) {
       const prompt = this.getPrompt(id);

--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -1244,7 +1244,11 @@ If you are using Vue, this may be because you are using the runtime-only build o
       .map((a: PromptAtom) => a.placeholderId!);
   }
 
-  setPromptValue(id: string, value?: string): void {
+  setPromptValue(
+    id: string,
+    value?: string,
+    insertOptions?: InsertOptions
+  ): void {
     if (value !== undefined) {
       const prompt = this.getPrompt(id);
       if (!prompt) {
@@ -1258,7 +1262,10 @@ If you are using Vue, this may be because you are using the runtime-only build o
       );
 
       this.model.setSelection(branchRange);
-      this.insert(value, { insertionMode: 'replaceSelection' });
+      this.insert(value, {
+        ...insertOptions,
+        insertionMode: 'replaceSelection',
+      });
     }
     requestUpdate(this);
   }

--- a/src/public/mathfield-element.ts
+++ b/src/public/mathfield-element.ts
@@ -2068,8 +2068,12 @@ import 'https://unpkg.com/@cortex-js/compute-engine?module';
     return this._mathfield?.getPromptState(id) ?? [undefined, true];
   }
 
-  setPromptContent(id: string, content: string): void {
-    this._mathfield?.setPromptValue(id, content);
+  setPromptContent(
+    id: string,
+    content: string,
+    insertOptions: Omit<InsertOptions, 'insertionMode'>
+  ): void {
+    this._mathfield?.setPromptValue(id, content, insertOptions);
   }
   get virtualKeyboardTargetOrigin(): string {
     return this._getOption('virtualKeyboardTargetOrigin');


### PR DESCRIPTION
Currently `setPromptContent` fires a `change` event, but I am calling `setPromptContent` on `change` (to strip answers from latex sent to a student). 