### PR TITLE
fix: Firefox and Safari selection issues, fixes #1898

### DIFF
--- a/src/editor/keyboard.ts
+++ b/src/editor/keyboard.ts
@@ -217,10 +217,9 @@ export function delegateKeyboardEvents(
 
       keydownEvent = event;
       keypressEvent = null;
-      if (!handlers.onKeystroke(keyboardEventToString(event), event)) {
+      if (!handlers.onKeystroke(keyboardEventToString(event), event))
         keydownEvent = null;
-        keyboardSink.textContent = '';
-      }
+      else keyboardSink.textContent = '';
     },
     true
   );


### PR DESCRIPTION
Adjusted the logic of when keyboardSink selection buffer is cleared. It is now cleared on keydown for any input that changes the buffer (fixes Firefox issue where it wasn't possible to replace a selection for a key press that wasn't a shortcut).

Buffer is no longer automatically cleared for non content changing commands so that Cmd-A and Shift-Arrow work to select on Safari. Arrow keys alone still work to clear selection buffer since this is handled by the current selection update logic.