### PR TITLE
fix: Deleting the Entire Math Expression by Backspacing on a Specific Symbol

### DIFF
--- a/src/editor-model/delete.ts
+++ b/src/editor-model/delete.ts
@@ -444,10 +444,7 @@ export function deleteRange(
     if (firstSelected === firstChild && lastSelected === lastChild) {
       const parent = result[0].parent!;
       if (parent.type !== 'root' && parent.type !== 'prompt') {
-        range = [
-          model.offsetOf(parent.leftSibling),
-          model.offsetOf(parent.rightSibling),
-        ];
+        range = [model.offsetOf(parent.leftSibling), model.offsetOf(parent)];
       }
     }
 


### PR DESCRIPTION
## Purpose

- Make math-field for entering LaTeX formulas work properly

## Reproducible Procedure

1. Prepare a math-field and input the expression \sqrt{a}b.
2. Select the symbol a that is inside the square root and press the backspace key.
3. The entire expression \sqrt{a}b will be deleted, leaving the input field blank.

## Implementation

![image](https://user-images.githubusercontent.com/84075821/228736694-b622f9a3-c7b7-4475-bcd9-40e0a1efd26f.png)

## Scope of the bug fix

- The code related to deleting the selected range when removing an internal element of elements such as sqrt.

## Additional Information

In this implementation, when deleting a child element such as "a" that is inside the square root the logic is designed to delete the entire expression. However, the deletion range is not properly defined, which causes the deletion of an unintended element one position to the right of the parent element.