### PR TITLE
insertPrompt command and widen empty prompt, allow latex mode in prompt

### DIFF
--- a/src/core-atoms/prompt.ts
+++ b/src/core-atoms/prompt.ts
@@ -183,29 +183,3 @@ export class PromptAtom extends Atom {
     return `\\placeholder${id}${correctness}${locked}{${value}}`;
   }
 }
-
-export function insertPrompt(
-  mathfield: Mathfield,
-  id?: string,
-  options?: InsertOptions
-): boolean {
-  const promptIds = mathfield.getPrompts();
-  let prosepectiveId = sixCharId();
-  let i = 0;
-  while (promptIds.includes(prosepectiveId) && i < 100) {
-    if (i === 99) {
-      console.error('could not find a unique ID after 100 tries');
-      return false;
-    }
-    prosepectiveId = sixCharId();
-    i++;
-  }
-  mathfield.insert(`\\placeholder[${id ?? prosepectiveId}]{}`, options);
-  return true;
-}
-
-function sixCharId() {
-  const max = 36 ** 6 - 1;
-  const min = 36 ** 5;
-  return Math.floor(Math.random() * (max - min) + min).toString(36);
-}

--- a/src/core-atoms/prompt.ts
+++ b/src/core-atoms/prompt.ts
@@ -5,9 +5,6 @@ import { Atom, AtomJson, ToLatexOptions } from '../core/atom-class';
 import { addSVGOverlay, Box } from '../core/box';
 import { Context } from '../core/context';
 import { convertDimensionToEm } from '../core/registers-utils';
-import { ModelPrivate } from 'editor-model/model-private';
-import { contentDidChange, contentWillChange } from 'editor-model/listeners';
-import { InsertOptions, Mathfield } from 'public/mathfield';
 
 export class PromptAtom extends Atom {
   readonly placeholderId?: string;

--- a/src/editor-mathfield/commands.ts
+++ b/src/editor-mathfield/commands.ts
@@ -6,6 +6,7 @@ import { toggleKeystrokeCaption } from './keystroke-caption';
 import { contentDidChange, contentWillChange } from '../editor-model/listeners';
 import { requestUpdate } from './render';
 import { ParseMode } from 'public/core-types';
+import { insertPrompt } from 'core-atoms/prompt';
 
 registerCommand({
   undo: (mathfield: MathfieldPrivate) => {
@@ -79,6 +80,7 @@ registerCommand({
     }
     return true;
   },
+  insertPrompt,
 });
 
 registerCommand(

--- a/src/editor-mathfield/commands.ts
+++ b/src/editor-mathfield/commands.ts
@@ -5,7 +5,7 @@ import { onInput } from './keyboard-input';
 import { toggleKeystrokeCaption } from './keystroke-caption';
 import { contentDidChange, contentWillChange } from '../editor-model/listeners';
 import { requestUpdate } from './render';
-import { ParseMode } from 'public/core-types';
+import { ParseMode } from '../public/core-types';
 
 registerCommand({
   undo: (mathfield: MathfieldPrivate) => {

--- a/src/editor-mathfield/commands.ts
+++ b/src/editor-mathfield/commands.ts
@@ -6,7 +6,6 @@ import { toggleKeystrokeCaption } from './keystroke-caption';
 import { contentDidChange, contentWillChange } from '../editor-model/listeners';
 import { requestUpdate } from './render';
 import { ParseMode } from 'public/core-types';
-import { insertPrompt } from 'core-atoms/prompt';
 
 registerCommand({
   undo: (mathfield: MathfieldPrivate) => {
@@ -80,7 +79,31 @@ registerCommand({
     }
     return true;
   },
-  insertPrompt,
+  insertPrompt: (
+    mathfield: MathfieldPrivate,
+    id?: string,
+    options?
+  ): boolean => {
+    const promptIds = mathfield.getPrompts();
+    let prosepectiveId =
+      'prompt-' +
+      Date.now().toString(36).slice(-2) +
+      Math.floor(Math.random() * 0x186a0).toString(36);
+    let i = 0;
+    while (promptIds.includes(prosepectiveId) && i < 100) {
+      if (i === 99) {
+        console.error('could not find a unique ID after 100 tries');
+        return false;
+      }
+      prosepectiveId =
+        'prompt-' +
+        Date.now().toString(36).slice(-2) +
+        Math.floor(Math.random() * 0x186a0).toString(36);
+      i++;
+    }
+    mathfield.insert(`\\placeholder[${id ?? prosepectiveId}]{}`, options);
+    return true;
+  },
 });
 
 registerCommand(

--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -1027,7 +1027,7 @@ If you are using Vue, this may be because you are using the runtime-only build o
   switchMode(mode: ParseMode, prefix = '', suffix = ''): void {
     if (
       this.mode === mode ||
-      this.readOnly ||
+      !this.hasEditablePrompts ||
       !this.contentEditable ||
       this.disabled
     )

--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -1027,7 +1027,7 @@ If you are using Vue, this may be because you are using the runtime-only build o
   switchMode(mode: ParseMode, prefix = '', suffix = ''): void {
     if (
       this.mode === mode ||
-      !this.hasEditablePrompts ||
+      !this.hasEditableContent ||
       !this.contentEditable ||
       this.disabled
     )

--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -1265,7 +1265,6 @@ If you are using Vue, this may be because you are using the runtime-only build o
         insertionMode: 'replaceSelection',
       });
     }
-    console.log(insertOptions?.suppressChangeNotifications);
     if (insertOptions?.suppressChangeNotifications)
       this.valueOnFocus = this.getValue();
     requestUpdate(this);

--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -1265,6 +1265,7 @@ If you are using Vue, this may be because you are using the runtime-only build o
         insertionMode: 'replaceSelection',
       });
     }
+    console.log(insertOptions?.suppressChangeNotifications);
     if (insertOptions?.suppressChangeNotifications)
       this.valueOnFocus = this.getValue();
     requestUpdate(this);

--- a/src/public/commands.ts
+++ b/src/public/commands.ts
@@ -129,6 +129,15 @@ export interface Commands {
   ) => boolean;
 
   /**
+   * @category Prompt
+   */
+  insertPrompt: (
+    mathfield: Mathfield,
+    id?: string,
+    options?: InsertOptions
+  ) => boolean;
+
+  /**
    * @category Array
    */
   addRowAfter: (model: Model) => boolean;


### PR DESCRIPTION
`insertPrompt` command inserts a prompt with random 6 char id or given `id`.

Prompts with no content were too small, so I widened them to `3 * fboxsep` (previously 2)