### PR TITLE
[draft] tests: add playwright end-to-end browser tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,29 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - name: Install dependencies
+      run: npm ci
+    - name: Build library
+      run: npm run build
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ ehthumbs.db
 Thumbs.db
 #IDE files
 .idea
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,3 +67,30 @@ Once your pull request has been accepted, it will be merged into the master
 branch.
 
 Congratulations, you've become a MathLive contributor! Thanks for your help!
+
+## Build Instructions
+[Node.js](https://nodejs.org) is used for MathLive development. If you don't already have node installed, the easiest way to get it installed is to use the [Volta](https://volta.sh/) node installer.
+
+First, [fork and clone](https://docs.github.com/en/get-started/quickstart/fork-a-repo) this repository. Then, in the cloned project folder, use the following commands to start a local dev server:
+``` bash
+# Install dependencies
+npm install
+
+# Run local dev server with live reload
+# After running this command, point your browser to http://127.0.0.1:8000/dist/smoke/
+npm run start
+```
+
+To run the test suite locally, run the following commands (if the dev server is running, close it using Ctrl-C before running these commands):
+``` bash
+# Install playwright browsers
+# This only needs to be done once for each version of playwright
+# Additional installation of browser dependencies may be required, follow instructions
+npx playwright install
+
+# Build the production version of MathLive
+npm run build
+
+# Run test suite
+npm run test
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,5 +92,8 @@ npx playwright install
 npm run build
 
 # Run test suite
-npm run test
+npm test
 ```
+
+Note that, because of how the dev server manages files, `npm run build` needs to be run before
+each `npm test` run. When debugging the Playwright browser tests, the `npx playwright test` command can be used to run only the Playwright tests. When running the Playwright tests directly, `npm run build` is not required. Also, the Playwright tests, when run with `npx playwright test`, can be run while the dev server is running.

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     '**/__tests__/**/*.+(ts|tsx|js)',
     '**/?(*.)+(spec|test).+(ts|tsx|js)',
   ],
+  testPathIgnorePatterns: ["<rootDir>/test/playwright-tests/"],
   // reporters: ['jest-silent-reporter'],
   moduleNameMapper: {
     '.*\\.(sass|less|css)$': '<rootDir>/test/__mocks__/styleMock.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@arnog/esbuild-plugin-less": "^1.1.0",
         "@cortex-js/compute-engine": "^0.12.2",
         "@cortex-js/prettier-config": "^1.1.1",
+        "@playwright/test": "^1.32.1",
         "@types/css-font-loading-module": "0.0.7",
         "@types/jest": "^29.4.0",
         "@typescript-eslint/eslint-plugin": "^5.49.0",
@@ -1591,6 +1592,25 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.1.tgz",
+      "integrity": "sha512-FTwjCuhlm1qHUGf4hWjfr64UMJD/z0hXYbk+O387Ioe6WdyZQ+0TBDAc6P+pHjx2xCv1VYNgrKbYrNixFWy4Dg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.32.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -5930,6 +5950,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright-core": {
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.1.tgz",
+      "integrity": "sha512-KZYUQC10mXD2Am1rGlidaalNGYk3LU1vZqqNk0gT4XPty1jOqgup8KDP8l2CUlqoNKhXM5IfGjWgW37xvGllBA==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
@@ -8697,6 +8729,17 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@playwright/test": {
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.1.tgz",
+      "integrity": "sha512-FTwjCuhlm1qHUGf4hWjfr64UMJD/z0hXYbk+O387Ioe6WdyZQ+0TBDAc6P+pHjx2xCv1VYNgrKbYrNixFWy4Dg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "fsevents": "2.3.2",
+        "playwright-core": "1.32.1"
       }
     },
     "@sinclair/typebox": {
@@ -11887,6 +11930,12 @@
           }
         }
       }
+    },
+    "playwright-core": {
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.1.tgz",
+      "integrity": "sha512-KZYUQC10mXD2Am1rGlidaalNGYk3LU1vZqqNk0gT4XPty1jOqgup8KDP8l2CUlqoNKhXM5IfGjWgW37xvGllBA==",
+      "dev": true
     },
     "postcss": {
       "version": "8.4.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@cortex-js/compute-engine": "^0.12.2",
         "@cortex-js/prettier-config": "^1.1.1",
         "@playwright/test": "^1.32.1",
-        "@types/css-font-loading-module": "0.0.7",
+        "@types/css-font-loading-module": "0.0.8",
         "@types/jest": "^29.4.0",
         "@typescript-eslint/eslint-plugin": "^5.49.0",
         "@typescript-eslint/parser": "^5.49.0",
@@ -1688,9 +1688,9 @@
       }
     },
     "node_modules/@types/css-font-loading-module": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
-      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.8.tgz",
+      "integrity": "sha512-PdJeLlCJj/ShOA+c0dXdZ/e1P0Cdjhip+dRBtPaigOqwKd0DiFx3NeO6T2E7AQ5JszSR3dub3YkQjc2hcQyxSw==",
       "dev": true
     },
     "node_modules/@types/graceful-fs": {
@@ -8827,9 +8827,9 @@
       }
     },
     "@types/css-font-loading-module": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
-      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.8.tgz",
+      "integrity": "sha512-PdJeLlCJj/ShOA+c0dXdZ/e1P0Cdjhip+dRBtPaigOqwKd0DiFx3NeO6T2E7AQ5JszSR3dub3YkQjc2hcQyxSw==",
       "dev": true
     },
     "@types/graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@cortex-js/compute-engine": "^0.12.2",
     "@cortex-js/prettier-config": "^1.1.1",
     "@playwright/test": "^1.32.1",
-    "@types/css-font-loading-module": "0.0.7",
+    "@types/css-font-loading-module": "0.0.8",
     "@types/jest": "^29.4.0",
     "@typescript-eslint/eslint-plugin": "^5.49.0",
     "@typescript-eslint/parser": "^5.49.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint --fix src/",
     "prepare": "bash ./scripts/build.sh production",
     "start": "bash ./scripts/start.sh",
-    "test": "bash ./scripts/test.sh; npx playwright test",
+    "test": "bash ./scripts/test.sh",
     "version": "bash ./scripts/version.sh",
     "postversion": "bash ./scripts/github-release.sh"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint --fix src/",
     "prepare": "bash ./scripts/build.sh production",
     "start": "bash ./scripts/start.sh",
-    "test": "bash ./scripts/test.sh",
+    "test": "bash ./scripts/test.sh; npx playwright test",
     "version": "bash ./scripts/version.sh",
     "postversion": "bash ./scripts/github-release.sh"
   },
@@ -101,6 +101,7 @@
     "@arnog/esbuild-plugin-less": "^1.1.0",
     "@cortex-js/compute-engine": "^0.12.2",
     "@cortex-js/prettier-config": "^1.1.1",
+    "@playwright/test": "^1.32.1",
     "@types/css-font-loading-module": "0.0.7",
     "@types/jest": "^29.4.0",
     "@typescript-eslint/eslint-plugin": "^5.49.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,73 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = 'http://127.0.0.1:8000'
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './test/playwright-tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: process.env.CI ? 'github' : 'list',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: baseURL,
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ..devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run start',
+    url: baseURL,
+    reuseExistingServer: true,
+  },
+});

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -65,6 +65,7 @@ echo -e "$LINECLEAR$BASENAME$CHECK${DIM}TypeScript declaration files built${RESE
 printf "$BASENAME${DOT}Copying static assets (fonts, sounds)"
 cp -f -R css/fonts dist/
 cp -f -R sounds dist/
+cp -f ./src/public/cortex-compute-engine.d.ts ./dist/public/
 echo -e "$LINECLEAR$BASENAME$CHECK${DIM}Static assets copied${RESET}"
 
 

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -12,6 +12,7 @@ context({
     './test/virtual-keyboard/index.html',
     './test/mathfield-states/index.html',
     './test/prompts/index.html',
+    './test/playwright-test-page/index.html'
   ],
   outdir: './dist',
   loader: {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -44,8 +44,7 @@ if [ ! -d "./dist/public" ]; then
   echo -e "\n❌ No build with declaration file available. Run 'npm run build'"
   exit 1    
 else
-#  npx tsc --noEmit --baseUrl ./dist/public ./test/public-ts-declarations/main.ts || exit_code=$?
-  echo "pass"
+  npx tsc --noEmit --baseUrl ./dist/public ./test/public-ts-declarations/main.ts || exit_code=$?
 fi
 
 # Run playwright end-to-end tests

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,37 +11,54 @@ cd "$(dirname "$0")/.."
 VARIANT="${1-test}"
 
 if [ ! -d "./dist" ]; then
-    echo -e "No build available. Run `npm run build` or `npm run dist`"
+    echo -e "\n❌ No build available. Run 'npm run build' or 'npm run dist'"
     exit 1    
 fi
 
+exit_code=0
+
+echo -e "\n🧐 Running unit tests..."
 
 if [ "$VARIANT" = "coverage" ]; then
     printf "\033[32m ● \033[0m Running test suite with coverage"
-    npx jest test/  --coverage
+    npx jest test/  --coverage || exit_code=$?
     echo -e "\033[2K\033[80D\033[32m ✔ \033[0m Test suite with coverage complete"
 elif [ "$VARIANT" = "snapshot" ]; then
     printf "\033[32m ● \033[0m Running test suite snapshot"
-    npx jest test/ -u
+    npx jest test/ -u || exit_code=$?
     echo -e "\033[2K\033[80D\033[32m ✔ \033[0m Test suite snapshot complete"
 else
     printf "\033[32m ● \033[0m Running test suite"
-    npx jest test/
+    npx jest test/ || exit_code=$?
     echo -e "\033[2K\033[80D\033[32m ✔ \033[0m Test suite complete"
 fi
-
 
 #
 # Validate that the public declaration files do not reference
 # private types
 #
 
+echo -e "\n🧐 Running type tests..."
 
 if [ ! -d "./dist/public" ]; then
-  echo -e "No build with declaration file available. Run `npm run build`"
+  echo -e "\n❌ No build with declaration file available. Run 'npm run build'"
   exit 1    
 else
+#  npx tsc --noEmit --baseUrl ./dist/public ./test/public-ts-declarations/main.ts || exit_code=$?
+  echo "pass"
+fi
 
-  npx tsc --noEmit --baseUrl ./dist/public ./test/public-ts-declarations/main.ts
+# Run playwright end-to-end tests
+echo -e "\n🧐 Running end-to-end tests..."
+npx playwright test || exit_code=$?
 
+echo $exit_code
+
+if [ "$exit_code" -eq "0" ]
+then
+  echo -e "\n🎉 All tests have completed successfully!"
+  exit 0
+else
+  echo -e "\n❌ At least one test has failed"
+  exit 1
 fi

--- a/src/public/mathfield-element.ts
+++ b/src/public/mathfield-element.ts
@@ -677,11 +677,11 @@ export class MathfieldElement extends HTMLElement implements Mathfield {
       | null
       | string
       | {
-        spacebar?: null | string;
-        return?: null | string;
-        delete?: null | string;
-        default: null | string;
-      }
+          spacebar?: null | string;
+          return?: null | string;
+          delete?: null | string;
+          default: null | string;
+        }
   ) {
     this.audioBuffers = {};
 
@@ -714,11 +714,11 @@ export class MathfieldElement extends HTMLElement implements Mathfield {
     delete: null | string;
     default: null | string;
   } = {
-      spacebar: 'keypress-spacebar.wav',
-      return: 'keypress-return.wav',
-      delete: 'keypress-delete.wav',
-      default: 'keypress-standard.wav',
-    };
+    spacebar: 'keypress-spacebar.wav',
+    return: 'keypress-return.wav',
+    delete: 'keypress-delete.wav',
+    default: 'keypress-standard.wav',
+  };
 
   /**
    * Sound played to provide feedback when a command has no effect, for example

--- a/src/public/mathfield-element.ts
+++ b/src/public/mathfield-element.ts
@@ -1,4 +1,4 @@
-/// <reference path="./cortex-compute-engine.d.ts" />
+/// <reference types="./cortex-compute-engine.d.ts" />
 
 import { Selector } from './commands';
 import type {
@@ -677,11 +677,11 @@ export class MathfieldElement extends HTMLElement implements Mathfield {
       | null
       | string
       | {
-          spacebar?: null | string;
-          return?: null | string;
-          delete?: null | string;
-          default: null | string;
-        }
+        spacebar?: null | string;
+        return?: null | string;
+        delete?: null | string;
+        default: null | string;
+      }
   ) {
     this.audioBuffers = {};
 
@@ -714,11 +714,11 @@ export class MathfieldElement extends HTMLElement implements Mathfield {
     delete: null | string;
     default: null | string;
   } = {
-    spacebar: 'keypress-spacebar.wav',
-    return: 'keypress-return.wav',
-    delete: 'keypress-delete.wav',
-    default: 'keypress-standard.wav',
-  };
+      spacebar: 'keypress-spacebar.wav',
+      return: 'keypress-return.wav',
+      delete: 'keypress-delete.wav',
+      default: 'keypress-standard.wav',
+    };
 
   /**
    * Sound played to provide feedback when a command has no effect, for example

--- a/src/public/mathlive-ssr.ts
+++ b/src/public/mathlive-ssr.ts
@@ -1,4 +1,4 @@
-/// <reference path="./cortex-compute-engine.d.ts" />
+/// <reference types="./cortex-compute-engine.d.ts" />
 
 /**
  * Server-side rendering exports.

--- a/test/mathfield-states/index.html
+++ b/test/mathfield-states/index.html
@@ -218,6 +218,9 @@
         <li>
           <a href="../prompts/">Prompts</a>
         </li>
+        <li>
+          <a href="../playwright-test-page/">Playwright Tests</a>
+        </li>
       </ul>
     </header>
     <main>

--- a/test/playwright-test-page/index.html
+++ b/test/playwright-test-page/index.html
@@ -19,6 +19,10 @@
         margin-top: 1em;
         margin-bottom: 1em;
       }
+
+      #mf-2::part(virtual-keyboard-toggle) {
+        display:none;
+      }
     </style>
   </head>
   <body>
@@ -26,7 +30,7 @@
       <h1>Virtual Keyboard Test</h1>
       <ul>
         <li><a href="../smoke/">Smoke</a></li>
-        <li class="current">
+        <li>
           <a href="../virtual-keyboard/">Virtual Keyboard</a>
         </li>
         <li>
@@ -35,7 +39,7 @@
         <li>
           <a href="../prompts/">Prompts</a>
         </li>
-        <li>
+        <li class="current">
           <a href="../playwright-test-page/">Playwright Tests</a>
         </li>
       </ul>
@@ -45,12 +49,14 @@
         >\sum^q_{n=0}\begin{pmatrix}a &amp; b \\ c &amp;
         d\end{pmatrix}</math-field
       >
+      <div>
       <math-field id="mf-2"
         >1+\texttip{a}{hello world}+b+\alpha+\mathtip{\alpha+\gamma}{x=\frac34}+
         \frac{a+1} {b+\mathtip{\alpha+\gamma}{x=\frac34} }+
         \frac{a+1}{b+\alpha+\gamma}</math-field
       >
-
+        Virtual Keyboard Toggle Hidden
+      </div>
       <textarea readonly disabled id="ta-1">hello world</textarea>
       <!-- <math-field id="mf" virtual-keyboard-mode="manual" readonly
         >f(x)= \placeholder[id1][x]{}</math-field

--- a/test/playwright-test-page/index.html
+++ b/test/playwright-test-page/index.html
@@ -93,22 +93,23 @@
 
       document.addEventListener("DOMContentLoaded", () => {
         const mfe3 = new MathfieldElement();
+        mfe3.id = "mf-3";
 
         mfe3.mathModeSpace = "\\:";
         mfe3.smartSuperscript = false;
-        mfe3.id = "mf-3";
 
         document.getElementById('mf-3-span').appendChild(mfe3);
 
 
         const mfe5 = new MathfieldElement();
+        mfe5.id = "mf-5";
 
         mfe5.addEventListener(
           'keydown',
           (ev) => {
             if (ev.key === '\\') {
               ev.preventDefault();
-              mf.executeCommand(['insert', '\\backslash']);
+              mfe5.executeCommand(['insert', '\\backslash']);
             } else if (ev.key === 'Escape') ev.preventDefault();
           },
           { capture: true }

--- a/test/playwright-test-page/index.html
+++ b/test/playwright-test-page/index.html
@@ -45,31 +45,34 @@
       </ul>
     </header>
     <main>
-      <math-field id="mf-1"
-        >\sum^q_{n=0}\begin{pmatrix}a &amp; b \\ c &amp;
-        d\end{pmatrix}</math-field
-      >
       <div>
-      <math-field id="mf-2"
-        >1+\texttip{a}{hello world}+b+\alpha+\mathtip{\alpha+\gamma}{x=\frac34}+
-        \frac{a+1} {b+\mathtip{\alpha+\gamma}{x=\frac34} }+
-        \frac{a+1}{b+\alpha+\gamma}</math-field
-      >
-        Virtual Keyboard Toggle Hidden
+        <math-field id="mf-1"></math-field>
+        #mf-1: default
       </div>
-      <textarea readonly disabled id="ta-1">hello world</textarea>
-      <!-- <math-field id="mf" virtual-keyboard-mode="manual" readonly
-        >f(x)= \placeholder[id1][x]{}</math-field
-      > -->
+      <div>
+        <math-field id="mf-2"></math-field>
+        #mf-2: Virtual Keyboard Toggle Hidden
+      </div>
+      <div>
+        <span id="mf-3-span"></span>
+        #mf-3: mathModeSpace='\\:', smartSuperscript=false
+      </div>
 
-      <!-- <math-field id="mf-prompt" readonly
-        >x=\frac{\placeholder[numer]{}}{\placeholder[denom][correct]{3}</math-field
-      > -->
+      <div>
+        <math-field readonly id="mf-4">x=\frac{3}{4}</math-field>
+        #mf-4: readonly
+      </div>
+
+      <div>
+        <span id="mf-5-span"></span>
+        #mf-5: latex mode disabled
+      </div>
+
+      <textarea readonly disabled id="ta-1">hello world</textarea>
+
       <math-field id="mf-prompt" readonly virtual-keyboard-mode="onfocus"
         >x=\frac{\placeholder[numer]{}}{\placeholder[denom][correct]{3}</math-field
       >
-
-      <math-field readonly id="mf-ro">x=\frac{3}{4}</math-field>
 
       <textarea id="ta-2"></textarea>
 
@@ -87,6 +90,34 @@
 
     <script type="module">
       import { MathfieldElement } from '/dist/mathlive.mjs';
+
+      document.addEventListener("DOMContentLoaded", () => {
+        const mfe3 = new MathfieldElement();
+
+        mfe3.mathModeSpace = "\\:";
+        mfe3.smartSuperscript = false;
+        mfe3.id = "mf-3";
+
+        document.getElementById('mf-3-span').appendChild(mfe3);
+
+
+        const mfe5 = new MathfieldElement();
+
+        mfe5.addEventListener(
+          'keydown',
+          (ev) => {
+            if (ev.key === '\\') {
+              ev.preventDefault();
+              mf.executeCommand(['insert', '\\backslash']);
+            } else if (ev.key === 'Escape') ev.preventDefault();
+          },
+          { capture: true }
+        );
+
+        document.getElementById('mf-5-span').appendChild(mfe5);
+      });
+
+
       let keyboardFrozen = false;
 
       const kbd = window.mathVirtualKeyboard;
@@ -376,22 +407,6 @@
 
       updateButtons();
 
-      // document.querySelectorAll('math-field, textarea').forEach((x) => {
-      //   x.addEventListener('beforeinput', logEvent);
-      //   x.addEventListener('input', logEvent);
-      //   x.addEventListener('keypress', logEvent);
-      //   x.addEventListener('keydown', logEvent);
-      //   x.addEventListener('keyup', logEvent);
-      //   x.addEventListener('click', logEvent);
-      //   x.addEventListener('focus', logEvent);
-      //   x.addEventListener('focusin', logEvent);
-      //   x.addEventListener('focusout', logEvent);
-      //   x.addEventListener('move-out', logEvent);
-      //   x.addEventListener('focus-in', logEvent);
-      //   x.addEventListener('focus-out', logEvent);
-      //   x.addEventListener('blur', logEvent);
-      // });
-
       kbd.addEventListener('geometrychange', logEvent);
       kbd.addEventListener('virtual-keyboard-toggle', logEvent);
       kbd.addEventListener('before-virtual-keyboard-toggle', logEvent);
@@ -409,112 +424,6 @@
         // console.log(evt);
         updateButtons();
       }
-
-      // mathVirtualKeyboard.layouts = {
-      //     rows: [
-      //       [
-      //         'a',
-      //         'b',
-      //         { class: 'separator w5' },
-      //         '7',
-      //         '8',
-      //         '9',
-      //         '\\div',
-      //         { class: 'separator w5' },
-      //         {
-      //           class: 'tex',
-      //           label: '<span><i>x</i>&thinsp;²</span>',
-      //           insert: '$$#@^{2}$$',
-      //         },
-      //         {
-      //           class: 'tex',
-      //           label: '<span><i>x</i><sup>&thinsp;<i>n</i></sup></span>',
-      //           insert: '$$#@^{}$$',
-      //         },
-      //         {
-      //           class: 'small',
-      //           latex: '\\sqrt{#0}',
-      //           insert: '$$\\sqrt{#0}$$',
-      //         },
-      //       ],
-      //       [
-      //         'c',
-      //         'd',
-      //         { class: 'separator w5' },
-      //         '4',
-      //         '5',
-      //         '6',
-      //         '\\times',
-      //         { class: 'separator w5' },
-      //         '\\frac{#0}{#0}',
-      //         { class: 'separator' },
-      //         { class: 'separator' },
-      //       ],
-      //       [
-      //         'x',
-      //         'y',
-      //         { class: 'separator w5' },
-
-      //         '1',
-      //         '2',
-      //         '3',
-      //         '-',
-      //         { class: 'separator w5' },
-      //         { class: 'separator' },
-      //         { class: 'separator' },
-      //         { class: 'separator' },
-      //       ],
-      //       [
-      //         '(',
-      //         ')',
-
-      //         { class: 'separator w5' },
-      //         '0',
-      //         '.',
-      //         '\\pi',
-      //         '+',
-      //         { class: 'separator w5' },
-      //         {
-      //           class: 'action',
-      //           label:
-      //             "<svg class=svg-glyph><use xlink:href='#svg-arrow-left' /></svg>",
-      //           command: ['performWithFeedback', 'moveToPreviousChar'],
-      //         },
-      //         {
-      //           class: 'action',
-      //           label:
-      //             "<svg class=svg-glyph><use xlink:href='#svg-arrow-right' /></svg>",
-      //           command: ['performWithFeedback', 'moveToNextChar'],
-      //         },
-      //         {
-      //           class: 'action font-glyph right',
-      //           label: '&#x232b;',
-      //           command: ['performWithFeedback', 'deleteBackward'],
-      //         },
-      //       ],
-      // };
-
-      // mathVirtualKeyboard.layouts = [
-      //   {
-      //     label: 'Minimal', // Label displayed in the Layout Switcher
-      //     tooltip: 'Only the essentials!',
-      //     rows: [
-      //       [
-      //         '+',
-      //         '-',
-      //         '\\times',
-      //         '\\frac{#@}{#?}',
-      //         '=',
-      //         '.',
-      //         '(',
-      //         ')',
-      //         '\\sqrt{#0}',
-      //         '#@^{#?}',
-      //       ],
-      //       ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'],
-      //     ],
-      //   },
-      // ];
 
       function updateButtons() {
         if (kbd.visible) {

--- a/test/playwright-tests/basic.spec.ts
+++ b/test/playwright-tests/basic.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+
+
+// Tests the following functionality on the smoke test page: 
+// Cmd-A select all, latex mode, press Enter to exit latex mode, smartSuperscript,
+// +- inline shortcut, down arrow for fraction navigation,
+// latex render, MathJson render, MathASCII render, MathML render,
+// speakable text render, selection latex, selection replace on type,
+// custom onInlineShortcut handler, replace * with \cdot
+test('smoke test', async ({ page, browserName }) => {
+  const modifierKey = /Mac|iPod|iPhone|iPad/.test(await page.evaluate( () => navigator.platform)) ? "Meta" : "Control";
+
+  let selectAllCommand = `${modifierKey}+a`;
+  if (modifierKey === "Meta" && browserName === "chromium") {
+    // Cmd-a not working with Chromium on Mac, need to use Control-A
+    selectAllCommand = 'Control+a';
+  }
+
+  await page.goto('/dist/smoke/');
+
+  await page.locator('math-field').press(selectAllCommand);
+  await page.locator('math-field').type('x=/-b+-\sqrt');
+  await page.locator('math-field').press('Enter');
+  await page.locator('math-field').type('b^2-4ac');
+  await page.locator('math-field').press('ArrowDown');
+  await page.locator('math-field').type('2a');
+
+  // check latex
+  await page.locator(String.raw`text=x=\frac{-b\pm\sqrt{b^2-4\mathrm{ac}}}{2a}`).waitFor();
+
+  // check MathJson
+  await page.locator('text=["Equal","x",["Divide",["Multiply",["Rational",1,2],["PlusMinus",["Negate","b"],["Sqrt",["Add",["Multiply",-4,"ac"],["Square","b"]]]]],"a"]]')
+            .waitFor();
+
+  // check MathASCII
+  await page.locator('text=x=(-b+-sqrt(b^2-4ac))/(2a)').waitFor();
+  
+  // check MathML
+  await page.locator('text=<mrow><mi>x</mi><mo>=</mo><mfrac><mrow><mo>−</mo><mi>b</mi><mo>&#177;</mo><msqrt><mrow><msup>b<mn>2</mn></msup><mo>−</mo><mn>4</mn><mo>&#8290;</mo><mi>ac</mi></mrow></msqrt></mrow><mrow><mn>2</mn><mo>&#8290;</mo><mi>a</mi></mrow></mfrac></mrow>')
+            .waitFor();
+
+  // check Speakable Text
+  await page.locator("text='X' equals the fraction minus 'B' plus or minus the square root of 'B' squared minus 4 'A' 'C'. End square root over 2 'A'. End fraction.")
+            .waitFor();
+
+  // select denominator
+  await page.locator('math-field').press('Shift+ArrowLeft');
+  await page.locator('math-field').press('Shift+ArrowLeft');
+
+  // check selection latex
+  await page.locator('text=value     "2a"').waitFor();
+
+  // replace only selection
+  await page.locator('math-field').type('2*z');
+
+  // check updated latex
+  await page.locator(String.raw`text=x=\frac{-b\pm\sqrt{b^2-4\mathrm{ac}}}{2\cdot z}`).waitFor();
+
+});
+
+

--- a/test/playwright-tests/mouse.spec.ts
+++ b/test/playwright-tests/mouse.spec.ts
@@ -1,0 +1,34 @@
+import { S } from '../../src/core/mathstyle';
+import type { MathfieldElement } from '../../src/public/mathfield-element';
+
+import { test, expect } from '@playwright/test';
+
+
+test('double/triple click to select', async ({ page }) => {
+  await page.goto('http://127.0.0.1:8000/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').type('(x+y)-(r+s)=34');
+
+  // double click to select clicked on block
+  await page.locator('#mf-1 >> span.ML__mathit >> text=r').dblclick();
+
+  // check selection latex
+  let selectionLatex = await page.locator('#mf-1').evaluate( (mfe: MathfieldElement) => {
+    return mfe.getValue(mfe.selection, 'latex');
+  });
+  expect(selectionLatex).toBe('r+s');
+
+  await page.locator('#mf-1').press('ArrowRight'); // unselect current selection
+  
+  // triple click to select it all
+  await page.locator('#mf-1 >> span.ML__cmr >> text=3').click({clickCount: 3, delay: 200});
+
+  // check selection latex
+  selectionLatex = await page.locator('#mf-1').evaluate( (mfe: MathfieldElement) => {
+    return mfe.getValue(mfe.selection, 'latex');
+  });
+  expect(selectionLatex).toBe(String.raw`\left(x+y\right)-\left(r+s\right)=34`);
+
+});
+
+

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -61,3 +61,108 @@ test('smoke test with physical keyboard', async ({ page, browserName }) => {
 
 });
 
+
+test('default space bar', async ({ page }) => {
+  await page.goto('http://127.0.0.1:8000/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').type('1/y +x');
+
+  // check that space bar navigated out of denominator of fraction
+  const latex = await page.locator('#mf-1').evaluate( (mfe: MathfieldElement) => {
+    return mfe.value;
+  });
+
+  expect(latex).toBe('\\frac{1}{y}+x');
+});
+
+
+test('custom mathModeSpace', async ({ page }) => {
+  await page.goto('http://127.0.0.1:8000/dist/playwright-test-page/');
+
+  await page.locator('#mf-3').type('1/y +x');
+
+  // check that space was inserted
+  const latex = await page.locator('#mf-3').evaluate( (mfe: MathfieldElement) => {
+    return mfe.value;
+  });
+
+  expect(latex).toBe('\\frac{1}{y\\:+x}');
+});
+
+
+test('tab focus', async ({ page }) => {
+  // For this one, need to be careful to not use locator.press or locator.type to prevent 
+  // playwright from managing focus
+
+  await page.goto('http://127.0.0.1:8000/dist/playwright-test-page/');
+
+  // focus first math field by clicking it then type
+  await page.locator('#mf-1').click();
+  await page.keyboard.type('a');  // type directly to page so that Playwright doesn't manage focus
+
+  // Tab to next math field and type
+  await page.keyboard.press('Tab'); // tab directly to page so that Playwright doesn't manage focus
+  await page.keyboard.type('b');
+
+  // make sure second math field is focused
+  await expect(page.locator('#mf-2')).toBeFocused();
+
+  // Tab to next math field and type
+  await page.keyboard.press('Tab');
+  await page.keyboard.type('c');
+
+  // Tab to next math field and type (this one is readonly, won't change anything)
+  await page.keyboard.press('Tab');
+  await page.keyboard.type('d');
+
+  // make sure readonly mathfield has focus
+  await expect(page.locator('#mf-4')).toBeFocused();
+
+  // Shift-Tab twice to get back to second math field and type 
+  await page.keyboard.press('Shift+Tab');
+  await page.keyboard.press('Shift+Tab');
+  await page.keyboard.type('e');
+
+  // check contents of all of the math fields
+  expect(await page.locator('#mf-1').evaluate( (e: MathfieldElement) => e.value)).toBe('a');
+  expect(await page.locator('#mf-2').evaluate( (e: MathfieldElement) => e.value)).toBe('be');
+  expect(await page.locator('#mf-3').evaluate( (e: MathfieldElement) => e.value)).toBe('c');
+
+});
+
+
+test('smartSuperscript', async ({ page }) => {
+  await page.goto('http://127.0.0.1:8000/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').type('y^3+z'); // smartSuperscript=true
+  await page.locator('#mf-3').type('y^3+z'); // smartSuperscript=false
+
+  // check results
+  expect(await page.locator('#mf-1').evaluate( (e: MathfieldElement) => e.value))
+    .toBe('y^3+z');
+  expect(await page.locator('#mf-3').evaluate( (e: MathfieldElement) => e.value))
+    .toBe('y^{3+z}');
+});
+
+
+test('cannot edit readonly mathfield', async ({ page}) => {
+  await page.goto('http://127.0.0.1:8000/dist/playwright-test-page/');
+
+  // focus readonly mathfield
+  await page.locator('#mf-4').focus();
+
+  // make sure readonly mathfield can receive focus
+  await expect(page.locator('#mf-4')).toBeFocused();
+
+  // check initial latex
+  expect(await page.locator('#mf-4').evaluate( (e: MathfieldElement) => e.value))
+    .toBe('x=\\frac{3}{4}');
+
+  // attempt to type into readonly mathfiled
+  await page.locator('#mf-4').type('abc');
+
+  // check that latex has not changed
+  expect(await page.locator('#mf-4').evaluate( (e: MathfieldElement) => e.value))
+    .toBe('x=\\frac{3}{4}');
+
+});

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -1,3 +1,5 @@
+import type { MathfieldElement } from '../../src/public/mathfield-element';
+
 import { test, expect } from '@playwright/test';
 
 
@@ -7,12 +9,13 @@ import { test, expect } from '@playwright/test';
 // latex render, MathJson render, MathASCII render, MathML render,
 // speakable text render, selection latex, selection replace on type,
 // custom onInlineShortcut handler, replace * with \cdot
-test('smoke test', async ({ page, browserName }) => {
+test('smoke test with physical keyboard', async ({ page, browserName }) => {
   const modifierKey = /Mac|iPod|iPhone|iPad/.test(await page.evaluate( () => navigator.platform)) ? "Meta" : "Control";
 
   let selectAllCommand = `${modifierKey}+a`;
   if (modifierKey === "Meta" && browserName === "chromium") {
     // Cmd-a not working with Chromium on Mac, need to use Control-A
+    // Cmd-a works correctly on Chrome and Edge on Mac
     selectAllCommand = 'Control+a';
   }
 
@@ -48,7 +51,7 @@ test('smoke test', async ({ page, browserName }) => {
   await page.locator('math-field').press('Shift+ArrowLeft');
 
   // check selection latex
-  await page.locator('text=value     "2a"').waitFor();
+  await page.locator('#selection >> text=2a').waitFor();
 
   // replace only selection
   await page.locator('math-field').type('2*z');
@@ -57,5 +60,4 @@ test('smoke test', async ({ page, browserName }) => {
   await page.locator(String.raw`text=x=\frac{-b\pm\sqrt{b^2-4\mathrm{ac}}}{2\cdot z}`).waitFor();
 
 });
-
 

--- a/test/playwright-tests/virtual-keyboard.spec.ts
+++ b/test/playwright-tests/virtual-keyboard.spec.ts
@@ -22,12 +22,12 @@ test('virtual keyboard with two math fields', async ({ page }) => {
 
   // press some keyboard buttons
   await page.getByRole('toolbar').getByText('abc').click();
-  await page.getByText('z', { exact: true }).click();
+  await page.getByText('zZ', { exact: true }).click();
   await page.getByRole('toolbar').getByText('123').click();
   await page.getByRole('listitem').filter({ hasText: '=' }).click();
-  await page.getByRole('listitem').filter({ hasText: '1' }).click();
+  await page.getByRole('listitem').filter({ hasText: '1' }).nth(1).click();
   await page.getByRole('listitem').filter({ hasText: '÷' }).click();
-  await page.getByRole('listitem').filter({ hasText: /^2$/ }).click();
+  await page.getByRole('listitem').filter({ hasText: '2' }).nth(1).click();
 
   // check resulting latex
   let latex = await page.locator('#mf-1').evaluate((mfe: MathfieldElement) => mfe.value);
@@ -36,10 +36,10 @@ test('virtual keyboard with two math fields', async ({ page }) => {
   // click to focus next math field to make sure virtual keyboard updates focused math field
   await page.locator('#mf-2').click();
 
-  await page.getByRole('listitem').filter({ hasText: /^x$/}).click();
-  await page.getByRole('listitem').filter({ hasText: '▢2'}).click();
-  await page.getByRole('list').locator('svg').nth(1).click({clickCount: 4, delay: 100});
-  await page.getByRole('listitem').filter({ hasText: /^n$/}).click();
+  await page.getByRole('listitem').filter({ hasText: 'x' }).click();
+  await page.getByRole('listitem').filter({ hasText: '2' }).nth(0).click();
+  await page.getByRole('list').locator('svg').nth(3).click({ clickCount: 4, delay: 200 });
+  await page.getByRole('listitem').filter({ hasText: 'na' }).click();
   await page.getByRole('listitem').filter({ hasText: '=' }).click();
 
   // check latex of second math field
@@ -53,6 +53,6 @@ test('virtual keyboard with two math fields', async ({ page }) => {
 
   // make sure that when no mathfield is focused that the virtual keyboard is hidden
   await page.locator('#ta-2').click();
-  await page.getByRole('toolbar').getByText('123').waitFor({state: "detached"});
+  await page.getByRole('toolbar').getByText('123').waitFor({ state: "detached" });
 
 });

--- a/test/playwright-tests/virtual-keyboard.spec.ts
+++ b/test/playwright-tests/virtual-keyboard.spec.ts
@@ -1,0 +1,65 @@
+import type { MathfieldElement } from '../../src/public/mathfield-element';
+
+import { test, expect } from '@playwright/test';
+
+
+test('virtual-keyboard-toggle visibility', async ({ page }) => {
+  await page.goto('http://127.0.0.1:8000/dist/playwright-test-page/');
+
+
+  expect(await page.locator('.ML__virtual-keyboard-toggle').nth(0).isVisible())
+    .toBe(true);
+
+
+  expect(await page.locator('.ML__virtual-keyboard-toggle').nth(1).isVisible())
+    .toBe(false);
+
+});
+
+
+test('virtual keyboard with two math fields', async ({ page }) => {
+  await page.goto('http://127.0.0.1:8000/dist/playwright-test-page/');
+
+  // clear the contents of the first two editable math fields
+  await page.locator('#mf-1').evaluate( (mfe: MathfieldElement) => mfe.value = '');
+  await page.locator('#mf-2').evaluate( (mfe: MathfieldElement) => mfe.value = '');
+
+  // toggle the virtual keyboard to visible and focus first math field
+  await page.locator('.ML__virtual-keyboard-toggle').nth(0).click();
+
+  // press some keyboard buttons
+  await page.getByRole('toolbar').getByText('abc').click();
+  await page.getByText('z', { exact: true }).click();
+  await page.getByRole('toolbar').getByText('123').click();
+  await page.getByRole('listitem').filter({ hasText: '=' }).click();
+  await page.getByRole('listitem').filter({ hasText: '1' }).click();
+  await page.getByRole('listitem').filter({ hasText: '÷' }).click();
+  await page.getByRole('listitem').filter({ hasText: /^2$/ }).click();
+
+  // check resulting latex
+  let latex = await page.locator('#mf-1').evaluate((mfe: MathfieldElement) => mfe.value);
+  expect(latex).toBe('z=\\frac{1}{2}');
+
+  // click to focus next math field to make sure virtual keyboard updates focused math field
+  await page.locator('#mf-2').click();
+
+  await page.getByRole('listitem').filter({ hasText: /^x$/}).click();
+  await page.getByRole('listitem').filter({ hasText: '▢2'}).click();
+  await page.getByRole('list').locator('svg').nth(1).click({clickCount: 4, delay: 100});
+  await page.getByRole('listitem').filter({ hasText: /^n$/}).click();
+  await page.getByRole('listitem').filter({ hasText: '=' }).click();
+
+  // check latex of second math field
+  // make sure first math field is unchanged
+  latex = await page.locator('#mf-2').evaluate((mfe: MathfieldElement) => mfe.value);
+  expect(latex).toBe('n=x^2');
+
+  // make sure first math field is unchanged
+  latex = await page.locator('#mf-1').evaluate((mfe: MathfieldElement) => mfe.value);
+  expect(latex).toBe('z=\\frac{1}{2}');
+
+  // make sure that when no mathfield is focused that the virtual keyboard is hidden
+  await page.locator('#ta-2').click();
+  await page.getByRole('toolbar').getByText('123').waitFor({state: "detached"});
+
+});

--- a/test/playwright-tests/virtual-keyboard.spec.ts
+++ b/test/playwright-tests/virtual-keyboard.spec.ts
@@ -20,10 +20,6 @@ test('virtual-keyboard-toggle visibility', async ({ page }) => {
 test('virtual keyboard with two math fields', async ({ page }) => {
   await page.goto('http://127.0.0.1:8000/dist/playwright-test-page/');
 
-  // clear the contents of the first two editable math fields
-  await page.locator('#mf-1').evaluate( (mfe: MathfieldElement) => mfe.value = '');
-  await page.locator('#mf-2').evaluate( (mfe: MathfieldElement) => mfe.value = '');
-
   // toggle the virtual keyboard to visible and focus first math field
   await page.locator('.ML__virtual-keyboard-toggle').nth(0).click();
 

--- a/test/playwright-tests/virtual-keyboard.spec.ts
+++ b/test/playwright-tests/virtual-keyboard.spec.ts
@@ -6,14 +6,11 @@ import { test, expect } from '@playwright/test';
 test('virtual-keyboard-toggle visibility', async ({ page }) => {
   await page.goto('http://127.0.0.1:8000/dist/playwright-test-page/');
 
-
   expect(await page.locator('.ML__virtual-keyboard-toggle').nth(0).isVisible())
     .toBe(true);
 
-
   expect(await page.locator('.ML__virtual-keyboard-toggle').nth(1).isVisible())
     .toBe(false);
-
 });
 
 

--- a/test/prompts/index.html
+++ b/test/prompts/index.html
@@ -28,8 +28,11 @@
         <li>
           <a href="../mathfield-states/">States</a>
         </li>
+        <li class="current">
+          <a href="../prompts/">Prompts</a>
+        </li>
         <li>
-          <a href="../prompts/" class="current">Prompts</a>
+          <a href="../playwright-test-page/" class="current">Playwright Tests</a>
         </li>
       </ul>
     </header>

--- a/test/smoke/index.html
+++ b/test/smoke/index.html
@@ -40,6 +40,9 @@
         <li>
           <a href="../prompts/">Prompts</a>
         </li>
+        <li>
+          <a href="../playwright-test-page/">Playwright Tests</a>
+        </li>
       </ul>
     </header>
     <main>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,6 +47,7 @@
     "examples",
     "docs",
     "tutorials",
-    "**/*.config.js"
+    "**/*.config.js",
+    "playwright.config.ts"
   ]
 }


### PR DESCRIPTION
This pull request adds [Playwright](https://playwright.dev/) end-to-end browser tests. Playwright is able to test against all of the major browser engines (Chromium, Firefox, and Webkit). This initial version has the basic framework implemented and an initial basic browser test using the smoke test page. I've also added a Github action to run the test suite (unit, type, and playwright) for commits to pull requests and commits to the main branch. The build and test process is the same as before with the exception that the playwright browsers need to be installed the first time a project is setup (or anytime playwright is upgraded) using the `npx playwright install` command. I've added instructions to the contributing document with these instructions in addition to the basic build instructions for MathLive. 

Let me know if this is something of interest to add to MathLive and I'll implement some additional tests (virtual keyboard, space bar handling, tab focus, editing options, etc.). 

These tests will be helpful for catching issues with particular browsers and to prevent regressions as features are added. The tests will be fragile at times. For example, insignificant changes, such as white space changes, to latex results will cause tests to fail and require them to be updated. However, I think the benefits will outweigh the inconveniences.