### PR TITLE
Don't hide the keyboard on focusout if mathVirtualKeyboardPolicy is manual

### DIFF
--- a/src/virtual-keyboard/virtual-keyboard.ts
+++ b/src/virtual-keyboard/virtual-keyboard.ts
@@ -187,7 +187,7 @@ export class VirtualKeyboard implements VirtualKeyboardInterface, EventTarget {
           }
           target = target.shadowRoot?.activeElement ?? null;
         }
-        if (!focusedMathfield) this.hide();
+        if (mf.mathVirtualKeyboardPolicy === 'auto' && !focusedMathfield) this.hide();
       }, 300);
     });
   }

--- a/src/virtual-keyboard/virtual-keyboard.ts
+++ b/src/virtual-keyboard/virtual-keyboard.ts
@@ -180,14 +180,16 @@ export class VirtualKeyboard implements VirtualKeyboardInterface, EventTarget {
       setTimeout(() => {
         let target = document.activeElement;
         let focusedMathfield = false;
+        let lastFocusedMathVirtualKeyboardPolicy = 'auto';
         while (target) {
           if (target.tagName?.toLowerCase() === 'math-field') {
             focusedMathfield = true;
+            lastFocusedMathVirtualKeyboardPolicy = target.mathVirtualKeyboardPolicy;
             break;
           }
           target = target.shadowRoot?.activeElement ?? null;
         }
-        if (mf.mathVirtualKeyboardPolicy === 'auto' && !focusedMathfield) this.hide();
+        if (lastFocusedMathVirtualKeyboardPolicy === 'auto' && !focusedMathfield) this.hide();
       }, 300);
     });
   }


### PR DESCRIPTION
If #1914 is a bug, I think this is one way to fix it, although it's not great because `mathVirtualKeyboardPolicy` is not a global setting, so I have to save it off the most recently focused `mathField`.

Fixes https://github.com/arnog/mathlive/issues/1914