### PR TITLE
Delimiter editing fixes

### DIFF
--- a/src/editor-mathfield/mode-editor-math.ts
+++ b/src/editor-mathfield/mode-editor-math.ts
@@ -642,7 +642,7 @@ export function insertSmartFence(
     ) {
       parent.leftDelim = fence;
       parent.isDirty = true;
-      contentDidChange(model, { data: fence, inputType: 'insertText'});
+      contentDidChange(model, { data: fence, inputType: 'insertText' });
       return true;
     }
 

--- a/src/editor-mathfield/mode-editor-math.ts
+++ b/src/editor-mathfield/mode-editor-math.ts
@@ -642,6 +642,7 @@ export function insertSmartFence(
     ) {
       parent.leftDelim = fence;
       parent.isDirty = true;
+      contentDidChange(model, { data: fence, inputType: 'insertText'});
       return true;
     }
 
@@ -756,7 +757,7 @@ export function insertSmartFence(
       const atom = model.at(i);
       if (
         atom instanceof LeftRightAtom &&
-        atom.rightDelim === '?' &&
+        (atom.rightDelim === '?' || atom.rightDelim === '.') &&
         isValidClose(atom.leftDelim, fence)
       )
         break;
@@ -767,9 +768,8 @@ export function insertSmartFence(
       match.rightDelim = fence;
       match.addChildren(
         model.extractAtoms([i, model.position]),
-        atom.parentBranch!
+        match.parentBranch!
       );
-      model.position = i;
       contentDidChange(model, { data: fence, inputType: 'insertText' });
       return true;
     }
@@ -779,7 +779,7 @@ export function insertSmartFence(
     // adjust the body (put everything after the insertion point outside)
     if (
       parent instanceof LeftRightAtom &&
-      parent.rightDelim === '?' &&
+      (parent.rightDelim === '?' || parent.rightDelim === '.') &&
       isValidClose(parent.leftDelim, fence)
     ) {
       parent.isDirty = true;
@@ -801,7 +801,7 @@ export function insertSmartFence(
     const grandparent = parent!.parent;
     if (
       grandparent instanceof LeftRightAtom &&
-      grandparent.rightDelim === '?' &&
+      (grandparent.rightDelim === '?' || grandparent.rightDelim === '.') &&
       model.at(model.position).isLastSibling
     ) {
       model.position = model.offsetOf(grandparent);

--- a/src/editor-mathfield/mode-editor-math.ts
+++ b/src/editor-mathfield/mode-editor-math.ts
@@ -660,7 +660,6 @@ export function insertSmartFence(
           model.offsetOf(atom),
           model.offsetOf(sibling),
         ]);
-        body.shift();
         body.pop();
         parent!.addChildrenAfter(
           [
@@ -671,7 +670,7 @@ export function insertSmartFence(
           ],
           atom
         );
-        model.position = model.offsetOf(parent!.firstChild);
+        model.position = model.offsetOf(parent!.firstChild) + 1;
         contentDidChange(model, { data: fence, inputType: 'insertText' });
         return true;
       }

--- a/test/playwright-test-page/index.html
+++ b/test/playwright-test-page/index.html
@@ -39,6 +39,8 @@
         <math-field id="mf-1"></math-field>
         #mf-1: default
       </div>
+      <div id="mf-1.value">
+      </div>
       <div>
         <math-field id="mf-2"></math-field>
         #mf-2: Virtual Keyboard Toggle Hidden
@@ -71,6 +73,12 @@
       import { MathfieldElement } from '/dist/mathlive.mjs';
 
       document.addEventListener('DOMContentLoaded', () => {
+        const mfe1 = document.getElementById('mf-1');
+        const mfe1Value = document.getElementById('mf-1.value')
+        mfe1.addEventListener('input', ()=> {
+          mfe1Value.innerText = mfe1.value;
+        });
+
         const mfe3 = new MathfieldElement();
         mfe3.id = 'mf-3';
 

--- a/test/playwright-tests/smart-fence.spec.ts
+++ b/test/playwright-tests/smart-fence.spec.ts
@@ -1,0 +1,113 @@
+import type { MathfieldElement } from '../../src/public/mathfield-element';
+
+import { test, expect } from '@playwright/test';
+
+// #1691
+test('right parenthesis first', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').type('1)');
+  await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').type('(');
+
+
+  // check that space bar navigated out of denominator of fraction
+  const latex = await page
+    .locator('#mf-1')
+    .evaluate((mfe: MathfieldElement) => {
+      return mfe.value;
+    });
+
+  expect(latex).toBe(String.raw`\left(1\right)`);
+});
+
+
+// #1375
+test('curly brackes', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').type('{a}');
+
+  let latex = await page
+    .locator('#mf-1')
+    .evaluate((mfe: MathfieldElement) => {
+      return mfe.value;
+    });
+
+  expect(latex).toBe(String.raw`\left\lbrace a\right\rbrace`);
+
+  await page.locator('#mf-1').press('Backspace');
+  await page.locator('#mf-1').press('Backspace');
+  await page.locator('#mf-1').press('Backspace');
+
+  latex = await page
+    .locator('#mf-1')
+    .evaluate((mfe: MathfieldElement) => {
+      return mfe.value;
+    });
+
+  expect(latex).toBe('');
+});
+
+
+// #1845
+test('mixed closing delimiter', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').press('Shift+|')
+  await page.locator('#mf-1').type('(1+2)');
+
+  const latex = await page
+    .locator('#mf-1')
+    .evaluate((mfe: MathfieldElement) => {
+      return mfe.value;
+    });
+
+  expect(latex).toBe(String.raw`\left|\left(1+2\right)\right|`);
+
+});
+
+
+// #1656 and #1742
+test('editing and re-adding right delimiter', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').type('1+cos()y')
+  await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').press('Backspace');
+  await page.locator('#mf-1').press('ArrowRight');
+  await page.locator('#mf-1').press('ArrowRight');
+  await page.locator('#mf-1').type(')')
+
+  const latex = await page
+    .locator('#mf-1')
+    .evaluate((mfe: MathfieldElement) => {
+      return mfe.value;
+    });
+
+  expect(latex).toBe(String.raw`1+\cos\left(y\right)`);
+
+});
+
+
+// issue where deleting and replacing left paranthesis doesn't trigger update
+test('editing and re-adding left delimiter', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').type('(1+2)')
+  await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').press('Backspace');
+  await page.locator('#mf-1').type('(');
+
+  const latex = await page.locator('#mf-1\\.value').textContent();
+
+  expect(latex).toBe(String.raw`\left(1+2\right)`);
+
+});
+
+
+

--- a/test/playwright-tests/smart-fence.spec.ts
+++ b/test/playwright-tests/smart-fence.spec.ts
@@ -110,4 +110,112 @@ test('editing and re-adding left delimiter', async ({ page }) => {
 });
 
 
+test('deleting and re-adding left delimiter outside leftright atom', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').type('1+(2+3)+4');
+  for(let i = 0; i < 6; i++) 
+    await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').press('Backspace');
+  for(let i = 0; i < 3; i++) 
+    await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').type('(');
+
+  const latex = await page
+    .locator('#mf-1')
+    .evaluate((mfe: MathfieldElement) => {
+      return mfe.value;
+    });
+
+  expect(latex).toBe(String.raw`\left(1+2+3\right)+4`);
+
+});
+
+
+test('deleting and re-adding left delimiter inside leftright atom', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').type('1+(2+3)+4');
+  for(let i = 0; i < 6; i++) 
+    await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').press('Backspace');
+  await page.locator('#mf-1').press('ArrowRight');
+  await page.locator('#mf-1').press('ArrowRight');
+  await page.locator('#mf-1').type('(');
+
+  const latex = await page
+    .locator('#mf-1')
+    .evaluate((mfe: MathfieldElement) => {
+      return mfe.value;
+    });
+
+  expect(latex).toBe(String.raw`1+2+\left(3\right)+4`);
+
+});
+
+
+test('deleting and re-adding right delimiter in place', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').type('1+(2+3)+4');
+  await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').press('Backspace');
+  await page.locator('#mf-1').type(')');
+
+  const latex = await page
+    .locator('#mf-1')
+    .evaluate((mfe: MathfieldElement) => {
+      return mfe.value;
+    });
+
+  expect(latex).toBe(String.raw`1+\left(2+3\right)+4`);
+
+});
+
+
+test('deleting and re-adding right delimiter outside leftright atom', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').type('1+(2+3)+4');
+  await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').press('Backspace');
+  await page.locator('#mf-1').press('ArrowRight');
+  await page.locator('#mf-1').press('ArrowRight');
+  await page.locator('#mf-1').press('ArrowRight');
+  await page.locator('#mf-1').type(')');
+
+  const latex = await page
+    .locator('#mf-1')
+    .evaluate((mfe: MathfieldElement) => {
+      return mfe.value;
+    });
+
+  expect(latex).toBe(String.raw`1+\left(2+3+4\right)`);
+
+});
+
+test('deleting and re-adding right delimiter inside leftright atom', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').type('1+(2+3)+4');
+  await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').press('Backspace');
+  await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').press('ArrowLeft');
+  await page.locator('#mf-1').type(')');
+
+  const latex = await page
+    .locator('#mf-1')
+    .evaluate((mfe: MathfieldElement) => {
+      return mfe.value;
+    });
+
+  expect(latex).toBe(String.raw`1+\left(2\right)+4+3`);
+
+});
+
+
 


### PR DESCRIPTION
Fixes #1656 and #1742 (#1742 is a duplicate of #1656). This pull request also fixes a regression of #1691 (the #1691 regression occurred since 0.91.2, I didn't determine exactly which commit introduced the regression). 

Additionally, fixes issue where deleting left delimiter and retyping left delimiter did not trigger an input event.

End-to-end tests have been added for these fixes and the previous delimiter issues (#1691, #1375,  and #1845) to make sure regressions were not introduced with these changes and to make sure any regressions on these issues will be detected in the future.