### PR TITLE
fix: switching tabs focus fix

### DIFF
--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -470,8 +470,8 @@ If you are using Vue, this may be because you are using the runtime-only build o
     if (window === window.top) {
       window.addEventListener(
         'blur',
-        () => {
-          if (isValidMathfield(this) && this.hasFocus()) {
+        (event) => {
+          if (!event.relatedTarget && isValidMathfield(this) && this.hasFocus()) {
             window.addEventListener(
               'focus',
               (evt) => {


### PR DESCRIPTION
Previously, math-field elements would steal focus from other focused element types when switching tabs. This caused quite a bit of issues with my app since it has many math-field and text input elements on the same page and switching tabs would cause a math-field element to always gain focus, even if a text input was previously focused, making it seem like a random element is being selected. This commit fixes this issue while still making sure #1545 remains fixed (math-field elements will still keep focus when changing tabs, just like textarea elements). 

The window blur event gets triggered even when not leaving a tab (focus switching between elements on the page). By checking that `event.relatedTarget` is null before adding the focusing callback, the callback is only added when the tab is actually losing focus.

I've verified that this fix works in Firefox, Chrome, and Safari. I'm unable to create a Playwright test for this case since Playwright doesn't currently allow a tab to lose focus [Playwright #11645](https://github.com/microsoft/playwright/issues/11645).

There's still an issue when nothing is selected and the most recently selected element was a math-field, that math-field will be selected when leaving and returning to the tab. However, this fix gets the behavior closer to a textarea and solves the most significant issues I was having with focus and tab switching.