### PR TITLE
Keyboard paste fix (fix #1937)

### DIFF
--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -433,9 +433,9 @@ If you are using Vue, this may be because you are using the runtime-only build o
         onCopy: (ev) => ModeEditor.onCopy(this, ev),
         onPaste: (ev) => {
           // Ignore if in read-only mode
-          let result = this.isSelectionEditable;          
+          let result = this.isSelectionEditable;
 
-          const text = ev.clipboardData?.getData("text");
+          const text = ev.clipboardData?.getData('text');
 
           if (result) {
             if (
@@ -484,7 +484,11 @@ If you are using Vue, this may be because you are using the runtime-only build o
       window.addEventListener(
         'blur',
         (event) => {
-          if (!event.relatedTarget && isValidMathfield(this) && this.hasFocus()) {
+          if (
+            !event.relatedTarget &&
+            isValidMathfield(this) &&
+            this.hasFocus()
+          ) {
             window.addEventListener(
               'focus',
               (evt) => {

--- a/src/editor/keybindings-definitions.ts
+++ b/src/editor/keybindings-definitions.ts
@@ -103,7 +103,6 @@ export const DEFAULT_KEYBINDINGS: Keybinding[] = [
   // Rare keys on some extended keyboards
   { key: '[Cut]', command: 'cutToClipboard' },
   { key: '[Copy]', command: 'copyToClipboard' },
-  { key: '[Paste]', command: 'pasteFromClipboard' },
   { key: '[Clear]', command: 'deleteBackward' },
   { key: '[Undo]', command: 'undo' },
   { key: '[Redo]', command: 'redo' },
@@ -113,8 +112,6 @@ export const DEFAULT_KEYBINDINGS: Keybinding[] = [
   { key: 'cmd+x', command: 'cutToClipboard' },
   { key: 'ctrl+c', command: 'copyToClipboard' },
   { key: 'cmd+c', command: 'copyToClipboard' },
-  { key: 'ctrl+v', command: 'pasteFromClipboard' },
-  { key: 'cmd+v', command: 'pasteFromClipboard' },
   { key: 'ctrl+z', ifPlatform: '!macos', command: 'undo' },
   { key: 'cmd+z', command: 'undo' },
   { key: 'ctrl+y', ifPlatform: '!macos', command: 'redo' }, // ARIA recommendation

--- a/test/playwright-tests/mouse.spec.ts
+++ b/test/playwright-tests/mouse.spec.ts
@@ -34,3 +34,23 @@ test('double/triple click to select', async ({ page }) => {
     });
   expect(selectionLatex).toBe(String.raw`\left(x+y\right)-\left(r+s\right)=34`);
 });
+
+test('readonly selectable', async ({ page, browserName }) => {
+
+  await page.goto('/dist/playwright-test-page/');
+
+  await page.locator('#mf-4').focus();
+
+  // triple click to select it all
+  await page
+    .locator('#mf-4 >> span.ML__cmr >> text=3')
+    .click({ clickCount: 3, delay: 200 });
+
+  // check contents of selection
+  let selectionLatex = await page
+    .locator('#mf-4')
+    .evaluate((mfe: MathfieldElement) => {
+      return mfe.getValue(mfe.selection, 'latex');
+    });
+  expect(selectionLatex).toBe('x=\\frac{3}{4}');
+});

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -325,3 +325,54 @@ test('nested paranthesis', async ({ page }) => {
     await page.locator('#mf-1').evaluate((e: MathfieldElement) => e.value)
   ).toBe(String.raw`\left(\left(\left(x+y\right)-r\right)-1\right)+30`);
 });
+
+
+test('keyboard copy/cut/paste', async ({ page, browserName }) => {
+  const modifierKey = /Mac|iPod|iPhone|iPad/.test(
+    await page.evaluate(() => navigator.platform)
+  )
+    ? 'Meta'
+    : 'Control';
+
+  let selectAllCommand = `${modifierKey}+a`;
+  if (modifierKey === 'Meta' && browserName === 'chromium') {
+    // Cmd-a not working with Chromium on Mac, need to use Control-A
+    // Cmd-a works correctly on Chrome and Edge on Mac
+    selectAllCommand = 'Control+a';
+  }
+
+  await page.goto('/dist/playwright-test-page/');
+
+  // add some content to the first math field
+  await page.locator('#mf-1').type('x+y=20');
+
+  // select math field contents and copy selection
+  await page.locator('#mf-1').press(selectAllCommand);
+  await page.locator('#mf-1').press(`${modifierKey}+c`);
+
+  // paste into second math field
+  await page.locator('#mf-2').press(`${modifierKey}+v`);
+
+  // check that paste was successful
+  expect(
+    await page.locator('#mf-2').evaluate((mfe: MathfieldElement) => mfe.value)
+  ).toBe('$$ x+y=20 $$');
+
+  // select all and cut contents for math field one
+  await page.locator('#mf-1').press(selectAllCommand);
+  await page.locator('#mf-1').press(`${modifierKey}+x`);
+
+  // check that cut was successful and that first mathfield is empty
+  expect(
+    await page.locator('#mf-1').evaluate((mfe: MathfieldElement) => mfe.value)
+  ).toBe('');
+
+  // paste cut contents into now empty math field 1
+  await page.locator('#mf-1').press(`${modifierKey}+v`);
+
+  // check contents of math field 1
+  expect(
+    await page.locator('#mf-1').evaluate((mfe: MathfieldElement) => mfe.value)
+  ).toBe('$$ x+y=20 $$');
+
+});

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -301,7 +301,7 @@ test('nested paranthesis', async ({ page }) => {
 
 
 test('keyboard copy/cut/paste', async ({ page, browserName }) => {
-  test.skip(browserName === "webkit", "copy-paste test doesn't work with webkit on linux");
+  test.skip(browserName !== "firefox", "with playwright, copy-paste test only works in firefox");
 
   const modifierKey = /Mac|iPod|iPhone|iPad/.test(
     await page.evaluate(() => navigator.platform)

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -228,33 +228,6 @@ test('Select all/type to replace selection', async ({ page, browserName }) => {
   ).toBe('30=z+y');
 });
 
-test('readonly selectable', async ({ page, browserName }) => {
-  const modifierKey = /Mac|iPod|iPhone|iPad/.test(
-    await page.evaluate(() => navigator.platform)
-  )
-    ? 'Meta'
-    : 'Control';
-
-  let selectAllCommand = `${modifierKey}+a`;
-  if (modifierKey === 'Meta' && browserName === 'chromium') {
-    // Cmd-a not working with Chromium on Mac, need to use Control-A
-    // Cmd-a works correctly on Chrome and Edge on Mac
-    selectAllCommand = 'Control+a';
-  }
-
-  await page.goto('/dist/playwright-test-page/');
-
-  await page.locator('#mf-4').press(selectAllCommand);
-
-  // check contents of selection
-  let selectionLatex = await page
-    .locator('#mf-4')
-    .evaluate((mfe: MathfieldElement) => {
-      return mfe.getValue(mfe.selection, 'latex');
-    });
-  expect(selectionLatex).toBe('x=\\frac{3}{4}');
-});
-
 test('test up/down arrow fraction navigation', async ({ page }) => {
   await page.goto('/dist/playwright-test-page/');
 
@@ -308,7 +281,7 @@ test('subscript and superscript', async ({ page }) => {
   // check latex of result
   expect(
     await page.locator('#mf-1').evaluate((e: MathfieldElement) => e.value)
-  ).toBe(String.raw`x_{y}^{h}+y_{rr}^{a}+z_1^{aa}+s_{11}^{bb}+30+x^{h}_{s}-40`);
+  ).toBe(String.raw`x_{y}^{h}+y_{rr}^{a}+z_1^{aa}+s_{11}^{bb}+30+x_{s}^{h}-40`);
 });
 
 test('nested paranthesis', async ({ page }) => {
@@ -328,6 +301,8 @@ test('nested paranthesis', async ({ page }) => {
 
 
 test('keyboard copy/cut/paste', async ({ page, browserName }) => {
+  test.skip(browserName === "webkit", "copy-paste test doesn't work with webkit on linux");
+
   const modifierKey = /Mac|iPod|iPhone|iPad/.test(
     await page.evaluate(() => navigator.platform)
   )


### PR DESCRIPTION
Same logic is now used for both keyboard paste and virtual keyboard paste. Only difference is that the keyboard paste uses `event.clipboardData` to avoid needing user permission. Pasting using virtual keyboard will still require a permission dialog on safari and chrome since `navigator.clipboard` needs to be used in that case. Virtual keyboard paste will not work on Firefox since Firefox doesn't implement the `navigator.clipboard` api.

I added a test as well for keyboard copy/paste. The test can only be run on Firefox due to limitations with Playwright. However, the new keyboard paste implementation works for Chrome and Safari, as well as firefox.

I also updated the E2E tests for recent changes (`Cmd-A` select all no longer works for read-only mathfields, mouse selection is used instead, and there is a order change for subscripts and superscripts in another test).