### PR TITLE
perf: defer getBoundingClientRect calls

### DIFF
--- a/src/public/virtual-keyboard.ts
+++ b/src/public/virtual-keyboard.ts
@@ -225,7 +225,7 @@ export interface MathfieldProxy {
   readonly mode: ParseMode;
   readonly style: Style;
   readonly array?: unknown;
-  readonly boundingRect?: DOMRect;
+  readonly field?: HTMLElement;
 }
 
 /**

--- a/src/virtual-keyboard/mathfield-proxy.ts
+++ b/src/virtual-keyboard/mathfield-proxy.ts
@@ -9,7 +9,7 @@ export function makeProxy(mf: MathfieldPrivate): MathfieldProxy {
     canRedo: mf.canRedo(),
     style: mf.selectionStyle,
     array: mf.model.parentEnvironment,
-    boundingRect: mf.field?.getBoundingClientRect(),
+    field: mf.field,
     mode: mf.mode,
   };
 }

--- a/src/virtual-keyboard/virtual-keyboard.ts
+++ b/src/virtual-keyboard/virtual-keyboard.ts
@@ -777,14 +777,15 @@ export class VirtualKeyboard implements VirtualKeyboardInterface, EventTarget {
   }
 
   updateEnvironmemtPopover(mf: MathfieldProxy): void {
+    const boundingRect = mf.field?.getBoundingClientRect();
     if (
       mf.array &&
       isTabularEnvironment((mf.array as ArrayAtom)?.environmentName) &&
-      mf.boundingRect &&
+      boundingRect &&
       this.visible &&
       mf.mode === 'math'
     )
-      showEnvironmentPanel(this, mf.array as ArrayAtom, mf.boundingRect);
+      showEnvironmentPanel(this, mf.array as ArrayAtom, boundingRect);
     else hideEnvironmentPanel(this);
 
     this._style = mf.style;

--- a/src/virtual-keyboard/virtual-keyboard.ts
+++ b/src/virtual-keyboard/virtual-keyboard.ts
@@ -777,16 +777,22 @@ export class VirtualKeyboard implements VirtualKeyboardInterface, EventTarget {
   }
 
   updateEnvironmemtPopover(mf: MathfieldProxy): void {
-    const boundingRect = mf.field?.getBoundingClientRect();
+    let hide = true;
+
     if (
       mf.array &&
       isTabularEnvironment((mf.array as ArrayAtom)?.environmentName) &&
-      boundingRect &&
       this.visible &&
       mf.mode === 'math'
-    )
-      showEnvironmentPanel(this, mf.array as ArrayAtom, boundingRect);
-    else hideEnvironmentPanel(this);
+    ) {
+      const boundingRect = mf.field?.getBoundingClientRect();
+      if (boundingRect) {
+        hide = false;
+        showEnvironmentPanel(this, mf.array as ArrayAtom, boundingRect);
+      }
+    }
+
+    if (hide) hideEnvironmentPanel(this);
 
     this._style = mf.style;
     this.updateToolbar(mf);


### PR DESCRIPTION
#1926 introduced a change where `getBoundingClientRect` was being called in `makeProxy`. `makeProxy` is triggered frequently during math-field and DOM updates (and during initial math-field creation). `getBoundingClientRect` is an expensive function and the frequent calls were causing performance issues during DOM updates and during page load for pages with a large number of math-field elements. Since `getBoundingClientRect` is only needed to place the environment popover when toggling the virtual keyboard, this change defers the call to `getBoundingClientRect` until it is  needed to place the popover. The existing functionality is unchanged.