### PR TITLE
Locale dependant mathfield

### DIFF
--- a/css/virtual-keyboard.less
+++ b/css/virtual-keyboard.less
@@ -1,4 +1,3 @@
-
 //
 // Breakpoints
 //
@@ -17,7 +16,7 @@
 @shadow4: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
 @shadow5: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
 
-// 
+//
 // blue-50   #e2f0fd
 // blue-100   #b6d9fb
 // blue-200   #86c0f9
@@ -86,7 +85,7 @@
 
   --keycap-shift-font-size: 16px;
   --keycap-shift-color: var(--keyboard-accent-color);
-  --environment-shadow: rgba(0,0,0,0.4);
+  --environment-shadow: rgba(0, 0, 0, 0.4);
 }
 
 .if-can-undo,
@@ -212,7 +211,7 @@ body > .ML__keyboard.is-visible.animate > .MLK__backdrop {
 
   background: var(--keyboard-background);
 
-  overflow: hidden;
+  // overflow: hidden;
 }
 
 .backdrop-is-transparent .MLK__backdrop {
@@ -412,7 +411,7 @@ body > .ML__keyboard.is-visible.animate > .MLK__backdrop {
       line-height: 0.8;
       font-size: calc(min(1rem, var(--keycap-small-font-size, 16px)));
       font-weight: 600;
-      padding: 8px 12px 8px 12px;      
+      padding: 8px 12px 8px 12px;
       &:hover {
         background: var(--keycap-secondary-background-hover);
       }
@@ -423,7 +422,7 @@ body > .ML__keyboard.is-visible.animate > .MLK__backdrop {
       color: #ddd;
     }
     .action.primary:hover {
-      background: #0d80f2 ; // blue-500
+      background: #0d80f2; // blue-500
       color: #fff;
     }
 
@@ -976,7 +975,7 @@ Note there are a different set of tooltip rules for the keyboard toggle
     --variant-panel-background: #303030;
     --variant-keycap-text: var(--keycap-text);
     --variant-keycap-text-active: #fff;
-    --environment-shadow: rgba(255,255,255,0.1);
+    --environment-shadow: rgba(255, 255, 255, 0.1);
   }
 }
 /* Same as the media query, but with a class */
@@ -986,7 +985,7 @@ Note there are a different set of tooltip rules for the keyboard toggle
   --keyboard-border: transparent;
   --keyboard-toolbar-text: #e3e4e8;
   --keyboard-toolbar-text-active: var(--keyboard-accent-color);
---keyboard-toolbar-background: transparent;
+  --keyboard-toolbar-background: transparent;
   --keyboard-toolbar-background-hover: #303030;
   --keyboard-toolbar-background-selected: transparent;
 
@@ -1010,7 +1009,7 @@ Note there are a different set of tooltip rules for the keyboard toggle
   --variant-panel-background: #303030;
   --variant-keycap-text: var(--keycap-text);
   --variant-keycap-text-active: #fff;
-  --environment-shadow: rgba(255,255,255,0.1);
+  --environment-shadow: rgba(255, 255, 255, 0.1);
 }
 
 [theme='light'] .ML__keyboard {
@@ -1059,17 +1058,17 @@ Note there are a different set of tooltip rules for the keyboard toggle
   background-color: var(--variant-panel-background, #fff);
   box-shadow: 0 0 30px 0 var(--environment-shadow, rgba(0, 0, 0, 0.4));
   pointer-events: all;
-  
+
   .MLK__array-buttons {
-    height: calc(var(--private-panel-height) * 5/4);
-    width: calc(var(--private-panel-height) * 5/4);
+    height: calc(var(--private-panel-height) * 5 / 4);
+    width: calc(var(--private-panel-height) * 5 / 4);
     margin-left: calc(0px - var(--private-panel-height) * 0.16);
     margin-top: calc(0px - var(--private-panel-height) * 0.19);
 
     .font {
       fill: white;
     }
-    
+
     circle {
       fill: #7f7f7f;
       transition: fill 300ms;
@@ -1122,18 +1121,21 @@ Note there are a different set of tooltip rules for the keyboard toggle
         }
         background-color: var(--keycap-background, white);
 
-        path, line {
+        path,
+        line {
           stroke: var(--keycap-text, #e3e4e8);
           stroke-width: 2;
           stroke-linecap: round;
         }
-        rect, path {
+        rect,
+        path {
           fill-opacity: 0;
         }
         &.active {
           pointer-events: none;
           background-color: var(--keycap-background-active, #f5f5f7);
-          path, line {
+          path,
+          line {
             stroke: var(--keyboard-accent-color, #0c75d8);
           }
           circle {
@@ -1143,5 +1145,4 @@ Note there are a different set of tooltip rules for the keyboard toggle
       }
     }
   }
-  
 }

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -9,10 +9,11 @@ context({
   entryPoints: [
     './test/style.css',
     './test/smoke/index.html',
+    './test/locale/index.html',
     './test/virtual-keyboard/index.html',
     './test/mathfield-states/index.html',
     './test/prompts/index.html',
-    './test/playwright-test-page/index.html'
+    './test/playwright-test-page/index.html',
   ],
   outdir: './dist',
   loader: {
@@ -35,10 +36,12 @@ context({
   sourceRoot: '../src',
   sourcesContent: false,
 }).then((ctx) =>
-  ctx.serve({ host: '127.0.0.1', port: 9029, servedir: '.' }).then(({ host, port }) => {
-    if (host === '0.0.0.0') host = 'localhost';
-    console.log(
-      ` 🚀 Server ready \u001b[1;35m http://${host}:${port}/dist/smoke/\u001b[0m`
-    );
-  })
+  ctx
+    .serve({ host: '127.0.0.1', port: 9029, servedir: '.' })
+    .then(({ host, port }) => {
+      if (host === '0.0.0.0') host = 'localhost';
+      console.log(
+        ` 🚀 Server ready \u001b[1;35m http://${host}:${port}/dist/smoke/\u001b[0m`
+      );
+    })
 );

--- a/src/core/context-utils.ts
+++ b/src/core/context-utils.ts
@@ -18,7 +18,7 @@ export function defaultGlobalContext(): GlobalContext {
     smartFence: false,
     fractionNavigationOrder: 'numerator-denominator',
     placeholderSymbol: '▢',
-    letterShapeStyle: l10n.locale.startsWith('fr') ? 'french' : 'tex',
+    letterShapeStyle: l10n.gLocale.startsWith('fr') ? 'french' : 'tex',
     colorMap: defaultColorMap,
     backgroundColorMap: defaultBackgroundColorMap,
     getDefinition: defaultGetDefinition,

--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -1217,19 +1217,8 @@ If you are using Vue, this may be because you are using the runtime-only build o
 
   focus(options?: FocusOptions): void {
     if (!this.hasFocus()) {
-      const prevMathfield = MathfieldElement.current;
-      const currentMathfield = (MathfieldElement.current = this
-        .host as MathfieldElement);
+      MathfieldElement.current = this.host as MathfieldElement;
       this.keyboardDelegate.focus();
-      if (
-        prevMathfield?.locale !== currentMathfield.locale &&
-        VirtualKeyboard.singleton.visible
-      ) {
-        const keyboard = VirtualKeyboard.singleton;
-        keyboard.hide();
-        keyboard.show();
-        keyboard.update(makeProxy(this)); // I don't know why but it this line is needed though it will be called inside the `connectToVirtualKeyboard` function
-      }
       this.connectToVirtualKeyboard();
       this.model.announce('line');
     }

--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -193,7 +193,7 @@ export class MathfieldPrivate implements GlobalContext, Mathfield {
   private geometryChangeTimer: ReturnType<typeof requestAnimationFrame>;
 
   /** When true, the mathfield is listening to the virtual keyboard */
-  private connectedToVirtualKeyboard: boolean;
+  connectedToVirtualKeyboard: boolean;
 
   /**
    *

--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -1217,8 +1217,19 @@ If you are using Vue, this may be because you are using the runtime-only build o
 
   focus(options?: FocusOptions): void {
     if (!this.hasFocus()) {
-      MathfieldElement.current = this.host as MathfieldElement;
+      const prevMathfield = MathfieldElement.current;
+      const currentMathfield = (MathfieldElement.current = this
+        .host as MathfieldElement);
       this.keyboardDelegate.focus();
+      if (
+        prevMathfield?.locale !== currentMathfield.locale &&
+        VirtualKeyboard.singleton.visible
+      ) {
+        const keyboard = VirtualKeyboard.singleton;
+        keyboard.hide();
+        keyboard.show();
+        keyboard.update(makeProxy(this)); // I don't know why but it this line is needed though it will be called inside the `connectToVirtualKeyboard` function
+      }
       this.connectToVirtualKeyboard();
       this.model.announce('line');
     }

--- a/src/editor/l10n-strings.ts
+++ b/src/editor/l10n-strings.ts
@@ -37,6 +37,8 @@ export const STRINGS = {
     'keyboard.tooltip.numeric': 'الرقمية',
     'keyboard.tooltip.alphabetic': 'رموز الاحرف الرومانية',
     'tooltip.copy to clipboard': 'نسخ إلى الحافظة',
+    'tooltip.cut to clipboard': 'قص إلى الحافظة',
+    'tooltip.paste from clipboard': 'لصق من الحافظة',
     'tooltip.redo': 'الإعادة',
     'tooltip.toggle virtual keyboard': 'تبديل لوحة المفاتيح الإفتراضية',
     'tooltip.undo': 'إلغاء',

--- a/src/editor/options.ts
+++ b/src/editor/options.ts
@@ -16,6 +16,7 @@ import { defaultExportHook } from '../editor-mathfield/mode-editor';
 import { INLINE_SHORTCUTS } from './shortcuts-definitions';
 import { DEFAULT_KEYBINDINGS } from './keybindings-definitions';
 import { VirtualKeyboard } from '../virtual-keyboard/global';
+import { isBrowser } from 'common/capabilities';
 
 /** @internal */
 export type MathfieldOptionsPrivate = MathfieldOptions & {
@@ -64,7 +65,7 @@ export function update(
       case 'letterShapeStyle':
         if (updates.letterShapeStyle === 'auto') {
           // Letter shape style (locale dependent)
-          if (l10n.locale.startsWith('fr')) result.letterShapeStyle = 'french';
+          if (l10n.gLocale.startsWith('fr')) result.letterShapeStyle = 'french';
           else result.letterShapeStyle = 'tex';
         } else result.letterShapeStyle = updates.letterShapeStyle!;
 
@@ -130,12 +131,14 @@ export function getDefault(): Required<MathfieldOptionsPrivate> {
   return {
     readOnly: false,
 
+    locale: isBrowser() ? navigator.language.slice(0, 5) : 'en',
+
     defaultMode: 'math',
     macros: getMacros(),
     registers: {},
     colorMap: defaultColorMap,
     backgroundColorMap: defaultBackgroundColorMap,
-    letterShapeStyle: l10n.locale.startsWith('fr') ? 'french' : 'tex',
+    letterShapeStyle: l10n.gLocale.startsWith('fr') ? 'french' : 'tex',
 
     smartMode: false,
     smartFence: true,

--- a/src/public/mathfield-element.ts
+++ b/src/public/mathfield-element.ts
@@ -357,7 +357,7 @@ const DEPRECATED_OPTIONS = {
   onExport: '`MathfieldElement.onExport`',
   onInlineShortcut: '`MathfieldElement.onInlineShortcut`',
   onScrollIntoView: '`MathfieldElement.onScrollIntoView`',
-  locale: 'MathfieldElement.locale = ...',
+  // locale: 'MathfieldElement.locale = ...',
   strings: 'MathfieldElement.strings = ...',
   decimalSeparator: 'MathfieldElement.decimalSeparator = ...',
   fractionNavigationOrder: 'MathfieldElement.fractionNavigationOrder = ...',
@@ -543,6 +543,10 @@ export class MathfieldElement extends HTMLElement implements Mathfield {
   static get formAssociated(): boolean {
     return isElementInternalsSupported();
   }
+
+  /** Current focused `MathfieldElement`. `undefined` if none is focused */
+  static current?: MathfieldElement;
+
   /**
    * Private lifecycle hooks
    * @internal
@@ -553,6 +557,7 @@ export class MathfieldElement extends HTMLElement implements Mathfield {
   > {
     return {
       'default-mode': 'string',
+      'locale': 'string',
       'letter-shape-style': 'string',
       'popover-policy': 'string',
 
@@ -880,17 +885,17 @@ export class MathfieldElement extends HTMLElement implements Mathfield {
     defaultReadAloudHook;
 
   /**
-   * The locale (language + region) to use for string localization.
+   * The global locale (language + region) to use for string localization.
    *
    * If none is provided, the locale of the browser is used.
    *
    */
-  static get locale(): string {
-    return l10n.locale;
+  static get gLocale(): string {
+    return l10n.gLocale;
   }
-  static set locale(value: string) {
+  static set gLocale(value: string) {
     if (value === 'auto') value = navigator.language.slice(0, 5);
-    l10n.locale = value;
+    l10n.gLocale = value;
   }
 
   /**
@@ -1574,6 +1579,15 @@ import 'https://unpkg.com/@cortex-js/compute-engine?module';
     return this._mathfield?.applyStyle(style, options);
   }
 
+  /** The local locale of the mathfield */
+  get locale(): string | undefined {
+    return this._mathfield?.options.locale;
+  }
+
+  set locale(val: string | undefined) {
+    if (this._mathfield) this._mathfield.setOptions({ locale: val });
+  }
+
   /**
    * The bottom location of the caret (insertion point) in viewport
    * coordinates.
@@ -1725,6 +1739,7 @@ import 'https://unpkg.com/@cortex-js/compute-engine?module';
           ? gDeferredState.get(this)!.options
           : getOptionsFromAttributes(this)),
         eventSink: this,
+        locale: this.getAttribute('locale') ?? undefined,
         value,
       }
     );

--- a/src/public/mathfield-element.ts
+++ b/src/public/mathfield-element.ts
@@ -1603,6 +1603,11 @@ import 'https://unpkg.com/@cortex-js/compute-engine?module';
     this._mathfield?.setCaretPoint(point.x, point.y);
   }
 
+  /** When true, the mathfield is listening to the virtual keyboard */
+  get isConnectedToVirtualKeyboard(): boolean | undefined {
+    return this._mathfield?.connectedToVirtualKeyboard;
+  }
+
   /**
    * `x` and `y` are in viewport coordinates.
    *

--- a/src/public/options.ts
+++ b/src/public/options.ts
@@ -535,6 +535,9 @@ export type MathfieldOptions = LayoutOptions &
   InlineShortcutsOptions &
   KeyboardOptions &
   MathfieldHooks & {
+    /** Custom locale option */
+    locale: string;
+
     /**
      * Specify the `targetOrigin` parameter for
      * [postMessage](https://developer.mozilla.org/en/docs/Web/API/Window/postMessage)

--- a/src/virtual-keyboard/utils.ts
+++ b/src/virtual-keyboard/utils.ts
@@ -268,7 +268,10 @@ export function normalizeLayout(
 /**
  * Return a markup string for the layouts toolbar for the specified layout.
  */
-function makeLayoutsToolbar(keyboard: VirtualKeyboard, index: number): string {
+export function makeLayoutsToolbar(
+  keyboard: VirtualKeyboard,
+  index: number
+): string {
   // The left hand side of the toolbar has a list of all the available keyboards
   let markup = `<div class="ML__layouts-toolbar left">`;
   if (keyboard.normalizedLayouts.length > 1) {

--- a/src/virtual-keyboard/utils.ts
+++ b/src/virtual-keyboard/utils.ts
@@ -110,7 +110,7 @@ function alphabeticLayout(): NormalizedVirtualKeyboardLayout {
             sk: 'qwertz',
             ch: 'qwertz',
           } as const
-        )[l10nOptions.locale.slice(0, 2)] ?? 'qwerty';
+        )[l10nOptions.gLocale.slice(0, 2)] ?? 'qwerty';
     }
   }
 

--- a/src/virtual-keyboard/utils.ts
+++ b/src/virtual-keyboard/utils.ts
@@ -270,7 +270,7 @@ export function normalizeLayout(
  */
 function makeLayoutsToolbar(keyboard: VirtualKeyboard, index: number): string {
   // The left hand side of the toolbar has a list of all the available keyboards
-  let markup = `<div class="left">`;
+  let markup = `<div class="ML__layouts-toolbar left">`;
   if (keyboard.normalizedLayouts.length > 1) {
     for (const [i, l] of keyboard.normalizedLayouts.entries()) {
       const layout = l;

--- a/src/virtual-keyboard/utils.ts
+++ b/src/virtual-keyboard/utils.ts
@@ -834,6 +834,7 @@ const KEYCAP_SHORTCUTS: Record<string, Partial<VirtualKeyboardKeycap>> = {
     class: 'ghost  if-can-redo',
     command: 'redo',
     label: '<svg class=svg-glyph><use xlink:href=#svg-redo /></svg>',
+    tooltip: l10n('tooltip.redo'),
   },
 
   '[(]': {

--- a/src/virtual-keyboard/utils.ts
+++ b/src/virtual-keyboard/utils.ts
@@ -268,10 +268,7 @@ export function normalizeLayout(
 /**
  * Return a markup string for the layouts toolbar for the specified layout.
  */
-export function makeLayoutsToolbar(
-  keyboard: VirtualKeyboard,
-  index: number
-): string {
+function makeLayoutsToolbar(keyboard: VirtualKeyboard, index: number): string {
   // The left hand side of the toolbar has a list of all the available keyboards
   let markup = `<div class="ML__layouts-toolbar left">`;
   if (keyboard.normalizedLayouts.length > 1) {

--- a/src/virtual-keyboard/virtual-keyboard.ts
+++ b/src/virtual-keyboard/virtual-keyboard.ts
@@ -29,7 +29,6 @@ import {
   releaseStylesheets,
   normalizeLayout,
   renderKeycap,
-  makeLayoutsToolbar,
 } from './utils';
 
 import { hideVariantsPanel, showVariantsPanel } from './variants';
@@ -765,24 +764,10 @@ export class VirtualKeyboard implements VirtualKeyboardInterface, EventTarget {
     el.classList.toggle('can-copy', !mf.selectionIsCollapsed);
     el.classList.toggle('can-paste', true);
 
-    const layoutToolbars = el.querySelectorAll('.ML__layouts-toolbar');
-    if (layoutToolbars) {
-      for (let i = 0; i < layoutToolbars.length; i++) {
-        const toolbar = layoutToolbars[i];
-        toolbar.innerHTML = makeLayoutsToolbar(this, i);
-        toolbar.parentElement!.insertBefore(
-          toolbar.firstElementChild!,
-          toolbar
-        );
-        toolbar.remove();
-      }
-    }
-
-    const editToolbars = el.querySelectorAll('.ML__edit-toolbar');
-    if (editToolbars) {
-      for (const toolbar of editToolbars)
-        toolbar.innerHTML = makeEditToolbar(this, mf);
-    }
+    const toolbars = el.querySelectorAll('.ML__edit-toolbar');
+    if (!toolbars) return;
+    for (const toolbar of toolbars)
+      toolbar.innerHTML = makeEditToolbar(this, mf);
   }
 
   update(mf: MathfieldProxy): void {

--- a/src/virtual-keyboard/virtual-keyboard.ts
+++ b/src/virtual-keyboard/virtual-keyboard.ts
@@ -29,6 +29,7 @@ import {
   releaseStylesheets,
   normalizeLayout,
   renderKeycap,
+  makeLayoutsToolbar,
 } from './utils';
 
 import { hideVariantsPanel, showVariantsPanel } from './variants';
@@ -764,10 +765,24 @@ export class VirtualKeyboard implements VirtualKeyboardInterface, EventTarget {
     el.classList.toggle('can-copy', !mf.selectionIsCollapsed);
     el.classList.toggle('can-paste', true);
 
-    const toolbars = el.querySelectorAll('.ML__edit-toolbar');
-    if (!toolbars) return;
-    for (const toolbar of toolbars)
-      toolbar.innerHTML = makeEditToolbar(this, mf);
+    const layoutToolbars = el.querySelectorAll('.ML__layouts-toolbar');
+    if (layoutToolbars) {
+      for (let i = 0; i < layoutToolbars.length; i++) {
+        const toolbar = layoutToolbars[i];
+        toolbar.innerHTML = makeLayoutsToolbar(this, i);
+        toolbar.parentElement!.insertBefore(
+          toolbar.firstElementChild!,
+          toolbar
+        );
+        toolbar.remove();
+      }
+    }
+
+    const editToolbars = el.querySelectorAll('.ML__edit-toolbar');
+    if (editToolbars) {
+      for (const toolbar of editToolbars)
+        toolbar.innerHTML = makeEditToolbar(this, mf);
+    }
   }
 
   update(mf: MathfieldProxy): void {

--- a/test/locale/index.html
+++ b/test/locale/index.html
@@ -49,7 +49,10 @@
       <!-- <div style="height: 2000px; border-left: 10px solid blue"></div> -->
       <!-- <math-field id="mf"> \not=\not{}=\not{\in} </math-field> -->
 
-      <math-field id="mf">x^{}y^</math-field>
+      <math-field id="mf" locale="ar">x^{}y^</math-field>
+      <math-field id="mf2">x^{}y^</math-field>
+      <math-field id="mf3">x^{}y^</math-field>
+      <math-field id="mf4" locale="bg">x^{}y^</math-field>
       <!-- <math-field id="mf"
         >\frac{}{1+x}\sqrt{}x^{}+y_{}+{}+\mathbb{}+\textcolor{red}{}</math-field
       > -->

--- a/test/mathfield-states/index.html
+++ b/test/mathfield-states/index.html
@@ -218,6 +218,9 @@
         <li>
           <a href="../prompts/">Prompts</a>
         </li>
+        <li>
+          <a href="../locale/">Multi Locale</a>
+        </li>
       </ul>
     </header>
     <main>

--- a/test/prompts/index.html
+++ b/test/prompts/index.html
@@ -31,6 +31,9 @@
         <li class="current">
           <a href="../prompts/">Prompts</a>
         </li>
+        <li>
+          <a href="../locale/">Multi Locale</a>
+        </li>
       </ul>
     </header>
     <main>

--- a/test/virtual-keyboard/index.html
+++ b/test/virtual-keyboard/index.html
@@ -44,6 +44,9 @@
           <a href="../prompts/">Prompts</a>
         </li>
         <li>
+          <a href="../locale/">Multi Locale</a>
+        </li>
+        <li>
           <a href="../playwright-test-page/">Playwright Tests</a>
         </li>
       </ul>


### PR DESCRIPTION
I faced a case where I will be using multiple mathfields in the same page, but wanted their locales to be different, intead of 1 locale to rule them all.

Please review and tell me if you have any comments. Also feel free to reject this merge request if you feel that it won't be benifical for you.

What I did was the following:
- Rename `locale` in the `l10n` object to `gLocale` (global locale)
- Add `local` to `MathfieldOptions`
- Add logic to get current focused mathfield from the `MathfieldElement` class

If a Mathfield doesn't have a locale, the `l10n` object's `gLocale` is used.

On switching between mathfields with different locales, First, I thought about updating the layout toolbar locale only instead of rebuilding the whole virtual keyboard. But I ended up with rebuilding the keyboard just to be safer, maybe some keycaps will have their own locale in the future for example.

When I tried to call the `VirtualKeyboard.singleton.rebuild` method to rebuild the keyboard on mathfield locale changes, the behavior wasn't quite right. So, I ended up calling the `hide`, `show`, and `update` methods Instead.

---

Other secondary changes: 
- Fix virtual keyboard toolbar tooltips not showing due to overflow hidden
- Add test page for multi locale mathfields
- Add missing redo tooltip
- Add 2 missing tooltips in `ar` locale
- Add `ML__layouts-toolbar` class to layouts toolbar markup. I just felt like it can be needed later
- Add `isConnectedToVirtualKeyboard` to `MathfieldElement` class. I just felt like it can be needed later
