### PR TITLE
Mimic mobile keyboard shift lock

### DIFF
--- a/src/editor-mathfield/keyboard-input.ts
+++ b/src/editor-mathfield/keyboard-input.ts
@@ -27,6 +27,7 @@ import { showKeystroke } from './keystroke-caption';
 import { ModeEditor } from './mode-editor';
 import { insertSmartFence } from './mode-editor-math';
 import type { ParseMode } from '../mathlive';
+import { VirtualKeyboard } from 'virtual-keyboard/virtual-keyboard';
 
 /**
  * Handler in response to a keystroke event.
@@ -479,7 +480,16 @@ export function onInput(
   // those with a skin tone modifier, the country flags emojis or
   // compound emojis such as the professional emojis, including the
   // David Bowie emoji: 👨🏻‍🎤
-  const graphemes = splitGraphemes(text);
+  let graphemes = splitGraphemes(text);
+
+  // Check if virtual keyboard is visible and the shift key is pressed
+  const keyboard = VirtualKeyboard.singleton;
+  if (keyboard.visible && keyboard.isShifted) {
+    graphemes =
+      typeof graphemes === 'string'
+        ? graphemes.toUpperCase()
+        : graphemes.map((c) => c.toUpperCase());
+  }
 
   if (model.mode === 'latex') {
     model.deferNotifications(

--- a/src/virtual-keyboard/utils.ts
+++ b/src/virtual-keyboard/utils.ts
@@ -1049,7 +1049,7 @@ function handlePointerDown(ev: PointerEvent) {
   // Is it the Shift key?
   if (isShiftKey(keycap)) {
     target.classList.add('is-active');
-    keyboard.isShifted = true;
+    keyboard.incrementShiftPress();
   }
 
   if (keycap.variants) {
@@ -1091,7 +1091,7 @@ function handleVirtualKeyboardEvent(controller) {
     if (ev.type === 'pointercancel') {
       target.classList.remove('is-pressed');
       if (isShiftKey(keycap)) {
-        keyboard.isShifted = false;
+        keyboard.decrementShiftPress();
         // Because of capslock, we may not have changed status
         target.classList.toggle('is-active', keyboard.isShifted);
       }
@@ -1102,7 +1102,7 @@ function handleVirtualKeyboardEvent(controller) {
     if (ev.type === 'pointerleave' && ev.target === target) {
       target.classList.remove('is-pressed');
       if (isShiftKey(keycap)) {
-        keyboard.isShifted = false;
+        keyboard.decrementShiftPress();
         // Because of capslock, we may not have changed status
         target.classList.toggle('is-active', keyboard.isShifted);
       }
@@ -1112,15 +1112,14 @@ function handleVirtualKeyboardEvent(controller) {
     if (ev.type === 'pointerup') {
       if (pressAndHoldTimer) clearTimeout(pressAndHoldTimer);
       if (isShiftKey(keycap)) {
-        keyboard.isShifted = false;
         // Because of capslock, we may not have changed status
         target.classList.toggle('is-active', keyboard.isShifted);
       } else if (target.classList.contains('is-pressed')) {
         target.classList.remove('is-pressed');
 
-        if (VirtualKeyboard.singleton.isShifted && keycap.shift) {
+        if (keyboard.isShifted && keycap.shift) {
           if (typeof keycap.shift === 'string') {
-            VirtualKeyboard.singleton.executeCommand([
+            keyboard.executeCommand([
               'insert',
               keycap.shift,
               {
@@ -1134,6 +1133,8 @@ function handleVirtualKeyboardEvent(controller) {
             ]);
           } else executeKeycapCommand(keycap.shift);
         } else executeKeycapCommand(keycap);
+
+        if (keyboard.shiftPressCount === 1) keyboard.resetShiftPress();
       }
       controller.abort();
       ev.preventDefault();

--- a/src/virtual-keyboard/virtual-keyboard.ts
+++ b/src/virtual-keyboard/virtual-keyboard.ts
@@ -70,6 +70,8 @@ export class VirtualKeyboard implements VirtualKeyboardInterface, EventTarget {
         ?.classList.remove('is-visible');
       newActive.classList.add('is-visible');
     }
+
+    if (this.isShifted) this.render();
   }
 
   private _isCapslock = false;

--- a/src/virtual-keyboard/virtual-keyboard.ts
+++ b/src/virtual-keyboard/virtual-keyboard.ts
@@ -77,10 +77,42 @@ export class VirtualKeyboard implements VirtualKeyboardInterface, EventTarget {
     return this._isCapslock;
   }
   set isCapslock(val: boolean) {
+    this._element?.classList.toggle('is-caps-lock', this.shiftPressCount === 2);
+
     if (val === this._isCapslock) return;
-    this._element?.classList.toggle('is-caps-lock', val);
+
     this._isCapslock = val;
     this.isShifted = val;
+  }
+
+  /** `0`: not pressed
+   *
+   * `1`: Shift is locked for next char only
+   *
+   * `2`: Shift is locked for all characters
+   */
+  private _shiftPressCount: 0 | 1 | 2 = 0;
+
+  get shiftPressCount(): 0 | 1 | 2 {
+    return this._shiftPressCount;
+  }
+
+  /** Increments `_shiftPressCount` by `1`, and handle the appropriate related behavior for each val */
+  incrementShiftPress(): void {
+    if (++this._shiftPressCount > 2) this.resetShiftPress();
+    else this.isCapslock = true;
+  }
+
+  /** Decrements `_shiftPressCount` by `1`, and sets `isCapslock` to `false` if reaches `0` */
+  decrementShiftPress(): void {
+    this._shiftPressCount = Math.max(--this._shiftPressCount, 0) as 0 | 1 | 2;
+    if (this._shiftPressCount === 0) this.isCapslock = false;
+  }
+
+  /** Resets `_shiftPressCount` to `0`, and sets `isCapslock` to `false` */
+  resetShiftPress(): void {
+    this._shiftPressCount = 0;
+    this.isCapslock = false;
   }
 
   private _isShifted = false;
@@ -580,22 +612,15 @@ export class VirtualKeyboard implements VirtualKeyboardInterface, EventTarget {
 
       case 'keydown': {
         const kev = evt as KeyboardEvent;
-
-        // Always update the capslock state. We could have gotten out of sync
-        // (i.e. if the capslock was reset in another window)
-        this.isCapslock = kev.getModifierState('CapsLock');
-
-        if (kev.key === 'Shift') this.isShifted = true;
+        if (kev.key === 'Shift') this.incrementShiftPress();
         break;
       }
       case 'keyup': {
         const kev = evt as KeyboardEvent;
-        if (kev.key === 'Shift') this.isShifted = false;
-
-        // The capslock key is "special" and may not get a keydown or keyup
-        // event, depending on its state. It varies by browser. Bottom line:
-        // to detect changes, check state on both keyup and keydown.
-        this.isCapslock = kev.getModifierState('CapsLock');
+        if (kev.key !== 'Shift' && this._shiftPressCount === 1) {
+          this.isCapslock = false;
+          this._shiftPressCount = 0;
+        }
         break;
       }
     }


### PR DESCRIPTION
I wanted to mimic the mobile keyboard's shift lock behavior.
- When you press shift once, it is locked, the next inserted character only will be inserted in uppercase, and the shift lock will reset.
- if pressed twice, it is locked, all the characters will be inserted in uppercase, and the shift lock will remain.
- if pressed trice, the shift lock will reset.

Other commits:
1. There was an issue: On switch virtual keyboard layer while the shift is pressed, the new layer keycap's aren't shifted. My fix was to call the `keyboard.render` method on setting the virtual keyboard's `currentLayer` attribute if the keyboard is shifted.
2. I also did something if you don't feel it's the behavior you need, feel free to revert it. if virtual keyboard shift is locked, insert the characters that were entered by the physical keyboard in uppercase.