### PR TITLE
Add regression tests

### DIFF
--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -325,3 +325,52 @@ test('nested paranthesis', async ({ page }) => {
     await page.locator('#mf-1').evaluate((e: MathfieldElement) => e.value)
   ).toBe(String.raw`\left(\left(\left(x+y\right)-r\right)-1\right)+30`);
 });
+
+test('sqrt inline shortcut (#1975)', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  // use latex mode for math field with default settings
+  await page.locator('#mf-1').type('sqrt22');
+  await page.locator('#mf-1').press('ArrowRight');
+  await page.locator('#mf-1').type('=x');
+
+  // check latex of result
+  expect(
+    await page.locator('#mf-1').evaluate((e: MathfieldElement) => e.value)
+  ).toBe(String.raw`\sqrt{22}=x`);
+});
+
+test('inline shortcut after long expression (#1978)', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  const startingLatex = String.raw`x=\frac{-b\pm\sqrt{b^2-4ac}}{2a}`;
+
+  await page.locator('#mf-1').evaluate((e: MathfieldElement, latex: string) => e.value = latex, startingLatex);
+
+  // use latex mode for math field with default settings
+  await page.locator('#mf-1').type('+alpha');
+
+  // check latex of result
+  expect(
+    await page.locator('#mf-1').evaluate((e: MathfieldElement) => e.value)
+  ).toBe(String.raw`x=\frac{-b\pm\sqrt{b^2-4ac}}{2a}+\alpha`);
+});
+
+test('keyboard select than divide (#1981)', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  // use latex mode for math field with default settings
+  await page.locator('#mf-1').type('x+y');
+  await page.locator('#mf-1').press('Shift+ArrowLeft');
+  await page.locator('#mf-1').press('Shift+ArrowLeft');
+  await page.locator('#mf-1').press('Shift+ArrowLeft');
+  await page.locator('#mf-1').type('/2');
+
+  // check latex of result
+  expect(
+    await page.locator('#mf-1').evaluate((e: MathfieldElement) => e.value)
+  ).toBe(String.raw`\frac{x+y}{2}`);
+});
+
+
+

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -372,5 +372,21 @@ test('keyboard select than divide (#1981)', async ({ page }) => {
   ).toBe(String.raw`\frac{x+y}{2}`);
 });
 
+test('text mode serialization (#1978)', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  // use latex mode for math field with default settings
+  await page.locator('#mf-1').type('x+y');
+  await page.locator('#mf-1').press(`Shift+'`);
+  await page.locator('#mf-1').type(' Comment ');
+  await page.locator('#mf-1').press(`Shift+'`);
+  await page.locator('#mf-1').type('z-s');
+
+  // check latex of result
+  expect(
+    await page.locator('#mf-1').evaluate((e: MathfieldElement) => e.value)
+  ).toBe(String.raw`x+y\text{ Comment }z-s`);
+});
+
 
 

--- a/test/playwright-tests/virtual-keyboard.spec.ts
+++ b/test/playwright-tests/virtual-keyboard.spec.ts
@@ -76,7 +76,9 @@ test('virtual keyboard with two math fields', async ({ page }) => {
     .waitFor({ state: 'detached' });
 });
 
-test('math fields in iframe with virtual keyboard', async ({ page }) => {
+test('math fields in iframe with virtual keyboard', async ({ page, browserName, context }) => {
+  test.skip(browserName === "webkit" && Boolean(process.env.CI), "Iframe test is flaky in webkit on GH actions");
+
   await page.goto('/dist/playwright-test-page/');
 
   const frame = page.frame('mathlive-iframe');


### PR DESCRIPTION
Adds regression tests for #1975, #1978, and #1981

Also skips webkit iframe test in CI only since this test fails most of the time in CI even though it passes locally. This iframe test is same origin, which is why it didn't catch #1982. The current iframe test is testing the virtual keyboard, so it needs to be same origin. #1982 uses the physical keyboard instead, I'll attempt to create a test for cross-origin physical keyboard once there's a fix for #1982. 