### PR TITLE
tests: add cross-origin Iframe test (#1982)

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -12,7 +12,8 @@ context({
     './test/virtual-keyboard/index.html',
     './test/mathfield-states/index.html',
     './test/prompts/index.html',
-    './test/playwright-test-page/index.html'
+    './test/playwright-test-page/index.html',
+    './test/playwright-test-page/iframe_test.html'
   ],
   outdir: './dist',
   loader: {

--- a/test/playwright-test-page/iframe_test.html
+++ b/test/playwright-test-page/iframe_test.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<script type="module">
+  import { MathfieldElement } from '/dist/mathlive.mjs';
+</script>
+<body>
+  Iframe Test (same origin, virtual keyboard will work):
+  <iframe
+    src="http://127.0.0.1:9029/dist/playwright-test-page/"
+    name="mathlive-iframe"
+    width="100%"
+    height="500px"
+  >
+  </iframe>
+  
+  Iframe Test (cross-origin, virtual keyboard will not work):
+  <iframe
+    src="http://localhost:9029/dist/playwright-test-page/"
+    name="mathlive-iframe-cross-origin"
+    width="100%"
+    height="500px"
+  >
+  </iframe>
+</body>
+</html>
+

--- a/test/playwright-test-page/index.html
+++ b/test/playwright-test-page/index.html
@@ -60,15 +60,6 @@
         #mf-5: latex mode disabled
       </div>
 
-      Iframe Test:
-      <iframe
-        src="http://127.0.0.1:9029/dist/playwright-test-page/"
-        name="mathlive-iframe"
-        width="100%"
-        height="500px"
-      >
-      </iframe>
-
       <textarea readonly disabled id="ta-1">hello world</textarea>
 
       <math-field id="mf-prompt" readonly virtual-keyboard-mode="onfocus"

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -388,5 +388,26 @@ test('text mode serialization (#1978)', async ({ page }) => {
   ).toBe(String.raw`x+y\text{ Comment }z-s`);
 });
 
+test('cross-origin iframe with physical keyboard', async ({ page, browserName, context }) => {
+  test.skip(browserName === "webkit" && Boolean(process.env.CI), "Iframe test is flaky in webkit on GH actions");
+
+  await page.goto('/dist/playwright-test-page/iframe_test.html');
+
+  const frame = page.frame('mathlive-iframe-cross-origin');
+
+  expect(frame).toBeTruthy();
+
+  if (frame) {
+    // type with physical keyboard
+    await frame.locator('#mf-1').type('x/20+x');
+
+    // check resulting latex
+    let latex = await frame
+      .locator('#mf-1')
+      .evaluate((mfe: MathfieldElement) => mfe.value);
+    expect(latex).toBe(String.raw`\frac{x}{20+z}`);
+  }
+});
+
 
 

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -399,7 +399,7 @@ test('cross-origin iframe with physical keyboard', async ({ page, browserName, c
 
   if (frame) {
     // type with physical keyboard
-    await frame.locator('#mf-1').type('x/20+x');
+    await frame.locator('#mf-1').type('x/20+z');
 
     // check resulting latex
     let latex = await frame

--- a/test/playwright-tests/virtual-keyboard.spec.ts
+++ b/test/playwright-tests/virtual-keyboard.spec.ts
@@ -79,7 +79,7 @@ test('virtual keyboard with two math fields', async ({ page }) => {
 test('math fields in iframe with virtual keyboard', async ({ page, browserName, context }) => {
   test.skip(browserName === "webkit" && Boolean(process.env.CI), "Iframe test is flaky in webkit on GH actions");
 
-  await page.goto('/dist/playwright-test-page/');
+  await page.goto('/dist/playwright-test-page/iframe_test.html');
 
   const frame = page.frame('mathlive-iframe');
 
@@ -97,32 +97,6 @@ test('math fields in iframe with virtual keyboard', async ({ page, browserName, 
       .locator('#mf-1')
       .evaluate((mfe: MathfieldElement) => mfe.value);
     expect(latex).toBe(expectedResult1);
-
-    // click to focus math field in current page to make sure virtual keyboard updates focused mathfield
-    await page.locator('text=#mf-1: default').click(); // need to click on page before focusing in page math field
-    await page.locator('#mf-1').focus();
-
-    const expectedResult2 = await virtualKeyboardSample2(page);
-
-    // check latex of in page math field
-    // make sure iframe math field is unchanged
-    latex = await page
-      .locator('#mf-1')
-      .evaluate((mfe: MathfieldElement) => mfe.value);
-    expect(latex).toBe(expectedResult2);
-
-    // make sure first math field is unchanged
-    latex = await frame
-      .locator('#mf-1')
-      .evaluate((mfe: MathfieldElement) => mfe.value);
-    expect(latex).toBe(expectedResult1);
-
-    // make sure that when no mathfield is focused that the virtual keyboard is hidden
-    await page.locator('#ta-2').click();
-    await page
-      .getByRole('toolbar')
-      .getByText('123')
-      .waitFor({ state: 'detached' });
   }
 });
 


### PR DESCRIPTION
Move iframe tests to their own page to prevent nested iframes. The same-origin iframe test uses the virtual keyboard and the cross-origin iframe test uses the phyiscal keybard