### PR TITLE
fix: selection highlight only for focused math-field

### DIFF
--- a/css/mathfield.less
+++ b/css/mathfield.less
@@ -220,7 +220,7 @@ with this style */
   opacity: 1;
 }
 
-.ML__selection {
+:host(:focus) .ML__selection {
   box-sizing: border-box;
   background: var(--_selection-background-color) !important;
 }


### PR DESCRIPTION
As mentioned in the gitter chat, this addresses selection highlighting showing for unfocused math-field elements after changes for 0.94.5