### PR TITLE
fix: added closing angle bracket in LaTeX to MathML conversion

### DIFF
--- a/src/addons/math-ml.ts
+++ b/src/addons/math-ml.ts
@@ -772,7 +772,7 @@ function atomToMathML(atom, options): string {
     case 'leftright':
       result = '<mrow>';
       if (atom.leftDelim && atom.leftDelim !== '.') {
-        result += `<mo${makeID(atom.id, options)}${
+        result += `<mo${makeID(atom.id, options)}>${
           SPECIAL_DELIMS[atom.leftDelim] ?? atom.leftDelim
         }</mo>`;
       }


### PR DESCRIPTION
In 'convertLatexToMathMl(...)' added closing angle bracket to '\<mo>' when left delim added