### PR TITLE
Virtual Keyboard display on older browsers

### DIFF
--- a/css/virtual-keyboard.less
+++ b/css/virtual-keyboard.less
@@ -379,22 +379,22 @@ body > .ML__keyboard.is-visible.animate > .MLK__backdrop {
     }
     .w5 {
       width: calc(
-        ~'min(var(--_keycap-max-width, 100px), 10cqw)' / 2 - var(--_keycap-gap);
+        ~'min(var(--_keycap-max-width, 100px), 10%)' / 2 - var(--_keycap-gap);
       );
     }
     .w15 {
       width: calc(
-        1.5 * ~'min(var(--_keycap-max-width, 100px), 10cqw)' - var(--_keycap-gap);
+        1.5 * ~'min(var(--_keycap-max-width, 100px), 10%)' - var(--_keycap-gap);
       );
     }
     .w20 {
       width: calc(
-        2 * ~'min(var(--_keycap-max-width, 100px), 10cqw)' -  var(--_keycap-gap);
+        2 * ~'min(var(--_keycap-max-width, 100px), 10%)' -  var(--_keycap-gap);
       );
     }
     .w50 {
       width: calc(
-        5 * ~'min(var(--_keycap-max-width, 100px), 10cqw)' -  var(--_keycap-gap);
+        5 * ~'min(var(--_keycap-max-width, 100px), 10%)' -  var(--_keycap-gap);
       );
     }
     .MLK__keycap.w50 {
@@ -481,7 +481,7 @@ body > .ML__keyboard.is-visible.animate > .MLK__backdrop {
       align-items: center;
       justify-content: space-evenly;
 
-      width: calc(~'min(var(--_keycap-max-width), 10cqw)' - var(--_keycap-gap));
+      width: calc(~'min(var(--_keycap-max-width), 10%)' - var(--_keycap-gap));
       height: var(--_keycap-height);
       box-sizing: border-box;
       padding: 0;


### PR DESCRIPTION
The keyboard does not display properly on browsers which do not support `cqw` as it is a relatively new feature. A friend had Chromium 103 installed when the minimum is 105 for this feature.

The good news is in the majority of places it is used for setting the width to a percentage width of the containing element, which `%` replaces seamlessly.

There still remains a 4cqw inside of `--_keycap-font-size` which can not be simply replaced with % because that scales relative to font size. On browsers which do not support `cqw` it will default to inherit.

closes  #2028