### PR TITLE
fix: typo in contains-highlight-background-color css variable

### DIFF
--- a/css/mathfield.less
+++ b/css/mathfield.less
@@ -47,7 +47,7 @@
 
   // The background color indicating the scope/zone of the caret, i.e. the
   // inside of a square root or a fraction.
-  --_contains-highlight-background-color: var(--contains-highlight-backround-color, hsl(var(--_hue), 40%, 95%));
+  --_contains-highlight-background-color: var(--contains-highlight-background-color, hsl(var(--_hue), 40%, 95%));
 
   // The color and opacity of a smart fence (automatically added ")" or "}")
   --_smart-fence-color: var(--smart-fence-color, currentColor);


### PR DESCRIPTION
Fixes typo in css variable name