### PR TITLE
fix: f, g, and h no longer impact behavior of /

### DIFF
--- a/src/core-definitions/definitions-utils.ts
+++ b/src/core-definitions/definitions-utils.ts
@@ -922,17 +922,6 @@ export function getDefinition(
     };
   }
 
-  // Special case `f`, `g` and `h` are recognized as functions.
-  if (
-    info &&
-    info.definitionType === 'symbol' &&
-    info.type === 'mord' &&
-    (info.codepoint === 0x66 ||
-      info.codepoint === 0x67 ||
-      info.codepoint === 0x68)
-  )
-    info.isFunction = true;
-
   return info ?? null;
 }
 


### PR DESCRIPTION
This pull request removes special treatment of f, g, and h as implicit functions while typing in expressions. The main side affect of the old behavior was that the divide command (typing /) worked differently for variables containing f, g, or h as compared to those without f, g, or h. Fixes #1869

In EngineeringPaper.xyz, the user needs to type in unit names, many of which contain f, g, or h. When typing a unit name with one of these letters, the divide command behavior is surprising, see the screen recording below:

https://github.com/arnog/mathlive/assets/6439649/c4cc79c9-bcdf-475b-813c-cddd9f253667

After this change, the behavior is consistent as with variables names that don't contain f, g, or h:

https://github.com/arnog/mathlive/assets/6439649/82ed75c0-bd15-474d-8563-88bd9322ab85

In this pull request, I simply removed the special treatment of f, g, and h. All of the current tests still pass. There doesn't seem to be other side affects besides the change in the behavior of the divide command. For example, the math json output doesn't seem to be impacted.

There's the possibility, of course, that I'm missing a side affect of this change. In that case, it may be desirable to keep the current behavior as the default and to provide the user the option to change which characters are treated as implicit functions.  If you would like me to implement this as an option, let me know, and I would be happy to implement. I was thinking it would be best to add to the `InlineShortcutsOptions` object as maybe `implicitFunctions`.

