### PR TITLE
increase long press & hold delay for key variants

### DIFF
--- a/src/virtual-keyboard/utils.ts
+++ b/src/virtual-keyboard/utils.ts
@@ -1080,7 +1080,7 @@ function handlePointerDown(ev: PointerEvent) {
           target?.classList.remove('is-active');
         });
       }
-    }, 200);
+    }, 300);
   }
 
   ev.preventDefault();


### PR DESCRIPTION
The current long press delay for keys is 200ms which is quite short, this PR increases it to 300ms for improved accessibility. 