### PR TITLE
sort typescript imports

### DIFF
--- a/src/addons/auto-render.ts
+++ b/src/addons/auto-render.ts
@@ -1,12 +1,11 @@
 /* eslint no-console:0 */
 
-import { AutoRenderOptions } from '../public/options';
+import '../core/atom';
 
 import { injectStylesheet } from '../common/stylesheet';
-
-import '../core/atom';
 import { loadFonts } from '../core/fonts';
 import { parseMathString } from '../editor/parse-math-string';
+import { AutoRenderOptions } from '../public/options';
 
 /** @internal */
 export type AutoRenderOptionsPrivate = AutoRenderOptions & {

--- a/src/addons/debug.ts
+++ b/src/addons/debug.ts
@@ -5,13 +5,13 @@
  */
 
 import {
+  ENVIRONMENTS,
   LATEX_COMMANDS,
   MATH_SYMBOLS,
   TEXT_SYMBOLS,
-  ENVIRONMENTS,
 } from '../core-definitions/definitions';
-import { DEFAULT_KEYBINDINGS } from '../editor/keybindings-definitions';
 import { getKeybindingMarkup } from '../editor/keybindings';
+import { DEFAULT_KEYBINDINGS } from '../editor/keybindings-definitions';
 
 const MathliveDebug = {
   FUNCTIONS: LATEX_COMMANDS,

--- a/src/addons/math-ml.ts
+++ b/src/addons/math-ml.ts
@@ -1,5 +1,5 @@
-import { Atom } from '../core/atom-class';
 import { MacroAtom } from '../core-atoms/macro';
+import { Atom } from '../core/atom-class';
 
 export type MathMLStream = {
   atoms: Atom[];

--- a/src/common/stylesheet.ts
+++ b/src/common/stylesheet.ts
@@ -1,20 +1,15 @@
 // @ts-ignore-error
-import MATHFIELD_STYLESHEET from '../../css/mathfield.less';
-
-// @ts-ignore-error
 import CORE_STYLESHEET from '../../css/core.less';
-
 // @ts-ignore-error
 import ENVIRONMENT_POPOVER_STYLESHEET from '../../css/environment-popover.less';
-
-// @ts-ignore-error
-import SUGGESTION_POPOVER_STYLESHEET from '../../css/suggestion-popover.less';
-
 // @ts-ignore-error
 import KEYSTROKE_CAPTION_STYLESHEET from '../../css/keystroke-caption.less';
-
 // @ts-ignore-error
-import VIRTUAL_KEYBOARD_STYLESHEET from '../../css/virtual-keyboard.less' assert { type: 'css' };
+import MATHFIELD_STYLESHEET from '../../css/mathfield.less';
+// @ts-ignore-error
+import SUGGESTION_POPOVER_STYLESHEET from '../../css/suggestion-popover.less';
+// @ts-ignore-error
+import VIRTUAL_KEYBOARD_STYLESHEET from '../../css/virtual-keyboard.less';
 
 type StylesheetId =
   | 'core'

--- a/src/core-atoms/accent.ts
+++ b/src/core-atoms/accent.ts
@@ -1,5 +1,5 @@
 import { Atom, AtomJson, CreateAtomOptions } from '../core/atom-class';
-import { makeSVGBox, Box } from '../core/box';
+import { Box, makeSVGBox } from '../core/box';
 import { Context } from '../core/context';
 import { X_HEIGHT } from '../core/font-metrics';
 import { VBox } from '../core/v-box';

--- a/src/core-atoms/array.ts
+++ b/src/core-atoms/array.ts
@@ -4,6 +4,7 @@ import type {
   Environment,
 } from '../public/core-types';
 
+import { isMatrixEnvironment } from '../core-definitions/environment-types';
 import {
   Atom,
   AtomJson,
@@ -13,15 +14,13 @@ import {
   ToLatexOptions,
 } from '../core/atom-class';
 import { Box } from '../core/box';
-import { VBox, VBoxElementAndShift } from '../core/v-box';
-import { makeLeftRightDelim } from '../core/delimiters';
 import { Context } from '../core/context';
-import { joinLatex } from '../core/tokenizer';
+import { makeLeftRightDelim } from '../core/delimiters';
 import { AXIS_HEIGHT, BASELINE_SKIP } from '../core/font-metrics';
 import { convertDimensionToEm } from '../core/registers-utils';
-
+import { joinLatex } from '../core/tokenizer';
+import { VBox, VBoxElementAndShift } from '../core/v-box';
 import { PlaceholderAtom } from './placeholder';
-import { isMatrixEnvironment } from '../core-definitions/environment-types';
 
 export type ColumnFormat =
   | {

--- a/src/core-atoms/delim.ts
+++ b/src/core-atoms/delim.ts
@@ -1,3 +1,4 @@
+import { getDefinition } from '../core-definitions/definitions-utils';
 import {
   Atom,
   AtomJson,
@@ -8,7 +9,6 @@ import { Box } from '../core/box';
 import { Context } from '../core/context';
 import { makeSizedDelim } from '../core/delimiters';
 import { latexCommand } from '../core/tokenizer';
-import { getDefinition } from '../core-definitions/definitions-utils';
 
 export class MiddleDelimAtom extends Atom {
   size: 1 | 2 | 3 | 4;

--- a/src/core-atoms/enclose.ts
+++ b/src/core-atoms/enclose.ts
@@ -1,10 +1,10 @@
 import type { Style } from '../public/core-types';
 
+import { getDefinition } from '../core-definitions/definitions-utils';
 import { Atom, AtomJson, ToLatexOptions } from '../core/atom-class';
 import { addSVGOverlay, Box } from '../core/box';
 import { Context } from '../core/context';
 import { latexCommand } from '../core/tokenizer';
-import { getDefinition } from '../core-definitions/definitions-utils';
 
 export type EncloseAtomOptions = {
   shadow?: string;

--- a/src/core-atoms/error.ts
+++ b/src/core-atoms/error.ts
@@ -1,4 +1,5 @@
 import { Atom, AtomJson } from '../core/atom-class';
+
 import type { Box } from '../core/box';
 import type { Context } from '../core/context';
 

--- a/src/core-atoms/genfrac.ts
+++ b/src/core-atoms/genfrac.ts
@@ -2,10 +2,10 @@ import type { MathstyleName, Style } from '../public/core-types';
 
 import { Atom, AtomJson } from '../core/atom-class';
 import { Box } from '../core/box';
-import { VBox } from '../core/v-box';
-import { makeCustomSizedDelim, makeNullDelimiter } from '../core/delimiters';
 import { Context } from '../core/context';
+import { makeCustomSizedDelim, makeNullDelimiter } from '../core/delimiters';
 import { AXIS_HEIGHT } from '../core/font-metrics';
+import { VBox } from '../core/v-box';
 
 export type GenfracOptions = {
   continuousFraction?: boolean;

--- a/src/core-atoms/group.ts
+++ b/src/core-atoms/group.ts
@@ -1,11 +1,11 @@
 import type { ParseMode, Style } from '../public/core-types';
 
+import { getDefinition } from '../core-definitions/definitions-utils';
 import { Atom, AtomJson, ToLatexOptions } from '../core/atom-class';
+
 import type { Context } from '../core/context';
 import type { Box } from '../core/box';
 import type { BoxType } from '../core/types';
-import { getDefinition } from '../core-definitions/definitions-utils';
-
 export class GroupAtom extends Atom {
   private boxType?: BoxType;
 

--- a/src/core-atoms/leftright.ts
+++ b/src/core-atoms/leftright.ts
@@ -2,8 +2,8 @@ import type { Style } from '../public/core-types';
 
 import { Atom, AtomJson, ToLatexOptions } from '../core/atom-class';
 import { Box } from '../core/box';
-import { makeLeftRightDelim, RIGHT_DELIM } from '../core/delimiters';
 import { Context } from '../core/context';
+import { makeLeftRightDelim, RIGHT_DELIM } from '../core/delimiters';
 import { joinLatex } from '../core/tokenizer';
 
 /**

--- a/src/core-atoms/macro.ts
+++ b/src/core-atoms/macro.ts
@@ -1,6 +1,7 @@
 import { Atom, AtomJson, ToLatexOptions } from '../core/atom-class';
-import { Context } from '../core/context';
 import { Box } from '../core/box';
+import { Context } from '../core/context';
+
 import type { Style } from '../public/core-types';
 
 export class MacroAtom extends Atom {

--- a/src/core-atoms/operator.ts
+++ b/src/core-atoms/operator.ts
@@ -1,5 +1,6 @@
 import type { Variant, VariantStyle } from '../public/core-types';
 
+import { getDefinition } from '../core-definitions/definitions-utils';
 import {
   Atom,
   AtomJson,
@@ -9,9 +10,8 @@ import {
 } from '../core/atom-class';
 import { Box } from '../core/box';
 import { Context } from '../core/context';
-import { joinLatex, latexCommand } from '../core/tokenizer';
 import { AXIS_HEIGHT } from '../core/font-metrics';
-import { getDefinition } from '../core-definitions/definitions-utils';
+import { joinLatex, latexCommand } from '../core/tokenizer';
 
 /**
  * Operators are handled in the TeXbook pg. 443-444, rule 13(a).

--- a/src/core-atoms/overlap.ts
+++ b/src/core-atoms/overlap.ts
@@ -1,6 +1,7 @@
 import { Atom, AtomJson, CreateAtomOptions } from '../core/atom-class';
 import { Box } from '../core/box';
 import { Context } from '../core/context';
+
 import type { BoxType } from '../core/types';
 
 export class OverlapAtom extends Atom {

--- a/src/core-atoms/overunder.ts
+++ b/src/core-atoms/overunder.ts
@@ -1,8 +1,9 @@
 import { Atom, AtomJson, CreateAtomOptions } from '../core/atom-class';
 import { Box, makeSVGBox } from '../core/box';
-import { VBox } from '../core/v-box';
 import { Context } from '../core/context';
 import { makeNullDelimiter } from '../core/delimiters';
+import { VBox } from '../core/v-box';
+
 import type { BoxType } from '../core/types';
 
 // An `overunder` atom has the following attributes:

--- a/src/core-atoms/phantom.ts
+++ b/src/core-atoms/phantom.ts
@@ -1,7 +1,7 @@
 import { Atom, AtomJson, CreateAtomOptions } from '../core/atom-class';
 import { Box } from '../core/box';
-import { VBox } from '../core/v-box';
 import { Context } from '../core/context';
+import { VBox } from '../core/v-box';
 
 export class PhantomAtom extends Atom {
   private readonly isInvisible: boolean;

--- a/src/core-atoms/spacing.ts
+++ b/src/core-atoms/spacing.ts
@@ -1,5 +1,6 @@
 import type { LatexValue } from '../public/core-types';
 
+import { getDefinition } from '../core-definitions/definitions-utils';
 import {
   Atom,
   AtomJson,
@@ -7,10 +8,9 @@ import {
   ToLatexOptions,
 } from '../core/atom-class';
 import { Box } from '../core/box';
-import type { Context } from '../core/context';
 import { serializeLatexValue } from '../core/registers-utils';
-import { getDefinition } from '../core-definitions/definitions-utils';
 
+import type { Context } from '../core/context';
 export class SpacingAtom extends Atom {
   private readonly width: LatexValue | undefined;
   private _braced: boolean;

--- a/src/core-atoms/surd.ts
+++ b/src/core-atoms/surd.ts
@@ -1,19 +1,18 @@
 import type { ParseMode } from '../public/core-types';
 
+import { getDefinition } from '../core-definitions/definitions-utils';
 import {
   Atom,
   AtomJson,
   CreateAtomOptions,
   ToLatexOptions,
 } from '../core/atom-class';
-import { X_HEIGHT } from '../core/font-metrics';
 import { Box } from '../core/box';
-import { VBox } from '../core/v-box';
 import { Context } from '../core/context';
-
 import { makeCustomSizedDelim } from '../core/delimiters';
+import { X_HEIGHT } from '../core/font-metrics';
 import { latexCommand } from '../core/tokenizer';
-import { getDefinition } from '../core-definitions/definitions-utils';
+import { VBox } from '../core/v-box';
 
 export class SurdAtom extends Atom {
   constructor(

--- a/src/core-atoms/text.ts
+++ b/src/core-atoms/text.ts
@@ -1,9 +1,9 @@
 import type { Style } from '../public/core-types';
 
+import { charToLatex } from '../core-definitions/definitions-utils';
 import { Atom, AtomJson, ToLatexOptions } from '../core/atom-class';
 import { Box } from '../core/box';
 import { Context } from '../core/context';
-import { charToLatex } from '../core-definitions/definitions-utils';
 
 export class TextAtom extends Atom {
   constructor(command: string, value: string, style: Style) {

--- a/src/core-atoms/tooltip.ts
+++ b/src/core-atoms/tooltip.ts
@@ -1,10 +1,11 @@
-import { Atom, AtomJson, CreateAtomOptions } from '../core/atom-class';
-import { Context } from '../core/context';
-import { Box, coalesce } from '../core/box';
-import { DEFAULT_FONT_SIZE } from '../core/font-metrics';
-import { fromJson } from '../core/atom';
-import { applyInterBoxSpacing } from '../core/inter-box-spacing';
 import { Argument } from 'core-definitions/definitions-utils';
+
+import { fromJson } from '../core/atom';
+import { Atom, AtomJson, CreateAtomOptions } from '../core/atom-class';
+import { Box, coalesce } from '../core/box';
+import { Context } from '../core/context';
+import { DEFAULT_FONT_SIZE } from '../core/font-metrics';
+import { applyInterBoxSpacing } from '../core/inter-box-spacing';
 
 export class TooltipAtom extends Atom {
   tooltip: Atom;

--- a/src/core-definitions/accents.ts
+++ b/src/core-definitions/accents.ts
@@ -1,13 +1,12 @@
-import { Atom } from '../core/atom-class';
 import { AccentAtom } from '../core-atoms/accent';
 import { OverunderAtom } from '../core-atoms/overunder';
-
+import { Atom } from '../core/atom-class';
+import { atomsBoxType } from '../core/box';
 import {
   argAtoms,
   defineFunction,
   parseArgAsString,
 } from './definitions-utils';
-import { atomsBoxType } from '../core/box';
 
 const ACCENTS = {
   acute: 0x02ca,

--- a/src/core-definitions/definitions-utils.ts
+++ b/src/core-definitions/definitions-utils.ts
@@ -1,5 +1,4 @@
 import { supportRegexPropertyEscape } from '../common/capabilities';
-
 import {
   Atom,
   AtomType,
@@ -7,9 +6,12 @@ import {
   CreateAtomOptions,
   ToLatexOptions,
 } from '../core/atom-class';
+import { Box } from '../core/box';
+import { MathfieldPrivate } from '../editor-mathfield/mathfield-private';
+import { unicodeToMathVariant } from './unicode';
+
 import type { ColumnFormat } from '../core-atoms/array';
 
-import { MathfieldPrivate } from '../editor-mathfield/mathfield-private';
 import type {
   ArgumentType,
   Dimension,
@@ -23,11 +25,8 @@ import type {
   Environment,
   LatexValue,
 } from '../public/core-types';
-import { unicodeToMathVariant } from './unicode';
 import type { ContextInterface, PrivateStyle } from '../core/types';
 import type { Context } from '../core/context';
-import { Box } from '../core/box';
-
 export type FunctionArgumentDefinition = {
   isOptional: boolean;
   type: ArgumentType;

--- a/src/core-definitions/definitions.ts
+++ b/src/core-definitions/definitions.ts
@@ -13,8 +13,8 @@ import './functions';
 import './mhchem';
 import './styling';
 import './symbols';
-
 import './definitions-utils';
+
 export * from './definitions-utils';
 
 export { MacroDictionary } from '../public/core-types';

--- a/src/core-definitions/enclose.ts
+++ b/src/core-definitions/enclose.ts
@@ -1,7 +1,7 @@
 import { CreateAtomOptions } from 'core/atom-class';
-import { EncloseAtom, EncloseAtomOptions } from '../core-atoms/enclose';
 
-import { Argument, argAtoms, defineFunction } from './definitions-utils';
+import { EncloseAtom, EncloseAtomOptions } from '../core-atoms/enclose';
+import { argAtoms, Argument, defineFunction } from './definitions-utils';
 
 // \enclose, a MathJax extension mapping to the MathML `menclose` tag.
 // The first argument is a comma delimited list of notations, as defined

--- a/src/core-definitions/environments.ts
+++ b/src/core-definitions/environments.ts
@@ -1,9 +1,8 @@
 import type { Dimension, Environment } from '../public/core-types';
 
-import { Atom } from '../core/atom-class';
-import { PlaceholderAtom } from '../core-atoms/placeholder';
 import { ArrayAtom, ColumnFormat } from '../core-atoms/array';
-
+import { PlaceholderAtom } from '../core-atoms/placeholder';
+import { Atom } from '../core/atom-class';
 import {
   Argument,
   defineEnvironment,

--- a/src/core-definitions/extensible-symbols.ts
+++ b/src/core-definitions/extensible-symbols.ts
@@ -1,6 +1,5 @@
 import type { ToLatexOptions } from '../core/atom-class';
 import { OverunderAtom } from '../core-atoms/overunder';
-
 import { argAtoms, defineFunction } from './definitions-utils';
 
 // Extensible (horizontally stretchy) symbols

--- a/src/core-definitions/functions.ts
+++ b/src/core-definitions/functions.ts
@@ -1,17 +1,15 @@
-import { joinLatex, latexCommand } from '../core/tokenizer';
-
-import { Atom, CreateAtomOptions } from '../core/atom-class';
-import { OperatorAtom } from '../core-atoms/operator';
-import { SurdAtom } from '../core-atoms/surd';
-import { GenfracAtom, GenfracOptions } from '../core-atoms/genfrac';
 import { MiddleDelimAtom } from '../core-atoms/delim';
-
-import { Argument, argAtoms, defineFunction } from './definitions-utils';
+import { GenfracAtom, GenfracOptions } from '../core-atoms/genfrac';
+import { OperatorAtom } from '../core-atoms/operator';
 import { PlaceholderAtom } from '../core-atoms/placeholder';
-import { serializeLatexValue } from '../core/registers-utils';
-import { LatexValue } from '../public/core-types';
-import { Context } from '../core/context';
+import { SurdAtom } from '../core-atoms/surd';
+import { Atom, CreateAtomOptions } from '../core/atom-class';
 import { Box } from '../core/box';
+import { Context } from '../core/context';
+import { serializeLatexValue } from '../core/registers-utils';
+import { joinLatex, latexCommand } from '../core/tokenizer';
+import { LatexValue } from '../public/core-types';
+import { argAtoms, Argument, defineFunction } from './definitions-utils';
 
 defineFunction(
   [

--- a/src/core-definitions/mhchem.ts
+++ b/src/core-definitions/mhchem.ts
@@ -16,10 +16,10 @@
 
 import { Atom, AtomJson, ToLatexOptions } from '../core/atom-class';
 import { parseLatex } from '../core/parser';
+import { defineFunction } from './definitions-utils';
+
 import type { Context } from '../core/context';
 import type { Box } from '../core/box';
-
-import { defineFunction } from './definitions-utils';
 
 export class ChemAtom extends Atom {
   private arg: string;

--- a/src/core-definitions/styling.ts
+++ b/src/core-definitions/styling.ts
@@ -1,21 +1,30 @@
+import '../core-atoms/genfrac';
+
+import { BoxAtom } from '../core-atoms/box';
+import { SizedDelimAtom } from '../core-atoms/delim';
+import { GroupAtom } from '../core-atoms/group';
+import { OverlapAtom } from '../core-atoms/overlap';
+import { OverunderAtom } from '../core-atoms/overunder';
+import { PhantomAtom } from '../core-atoms/phantom';
+import { SpacingAtom } from '../core-atoms/spacing';
+import { TooltipAtom } from '../core-atoms/tooltip';
 import {
   Atom,
   BBoxParameter,
   CreateAtomOptions,
   ToLatexOptions,
 } from '../core/atom-class';
+import { atomsBoxType, Box } from '../core/box';
+import { Context } from '../core/context';
+import { S, Sc, SS, SSc, T, Tc } from '../core/mathstyle';
+import {
+  multiplyLatexValue,
+  serializeLatexValue,
+} from '../core/registers-utils';
+import { joinLatex, latexCommand } from '../core/tokenizer';
+import { VBox } from '../core/v-box';
+import { argAtoms, Argument, defineFunction } from './definitions-utils';
 
-import { GroupAtom } from '../core-atoms/group';
-import { BoxAtom } from '../core-atoms/box';
-import { PhantomAtom } from '../core-atoms/phantom';
-import { SizedDelimAtom } from '../core-atoms/delim';
-import { SpacingAtom } from '../core-atoms/spacing';
-import { OverunderAtom } from '../core-atoms/overunder';
-import { OverlapAtom } from '../core-atoms/overlap';
-import '../core-atoms/genfrac';
-
-import { Argument, argAtoms, defineFunction } from './definitions-utils';
-import { TooltipAtom } from '../core-atoms/tooltip';
 import type {
   FontSize,
   FontSeries,
@@ -25,16 +34,6 @@ import type {
   FontFamily,
 } from '../public/core-types';
 import type { PrivateStyle } from '../core/types';
-import { joinLatex, latexCommand } from '../core/tokenizer';
-import { Box, atomsBoxType } from '../core/box';
-import {
-  multiplyLatexValue,
-  serializeLatexValue,
-} from '../core/registers-utils';
-import { Context } from '../core/context';
-import { T, Tc, S, Sc, SS, SSc } from '../core/mathstyle';
-import { VBox } from '../core/v-box';
-
 defineFunction('mathtip', '{:auto}{:math}', {
   createAtom: (
     options: CreateAtomOptions<[Argument | null, Argument | null]>

--- a/src/core-definitions/symbols.ts
+++ b/src/core-definitions/symbols.ts
@@ -1,9 +1,8 @@
 import { SpacingAtom } from '../core-atoms/spacing';
-
 import {
-  newSymbols,
-  newSymbolRange,
   defineFunction,
+  newSymbolRange,
+  newSymbols,
 } from './definitions-utils';
 
 // See http://www.gang.umass.edu/~franz/latexmanual.pdf p. 139

--- a/src/core/atom-class.ts
+++ b/src/core/atom-class.ts
@@ -5,19 +5,18 @@ import type {
   LatexValue,
 } from '../public/core-types';
 
-import { PT_PER_EM, X_HEIGHT } from './font-metrics';
-import { boxType, Box } from './box';
-import { makeLimitsStack, VBox } from './v-box';
-import { joinLatex, latexCommand } from './tokenizer';
-import { Mode } from './modes-utils';
 import {
   Argument,
   getDefinition,
   unicodeCharToLatex,
 } from '../core-definitions/definitions-utils';
-
+import { Box, boxType } from './box';
 import { Context } from './context';
-import { PrivateStyle, BoxType } from './types';
+import { PT_PER_EM, X_HEIGHT } from './font-metrics';
+import { Mode } from './modes-utils';
+import { joinLatex, latexCommand } from './tokenizer';
+import { BoxType, PrivateStyle } from './types';
+import { makeLimitsStack, VBox } from './v-box';
 
 /**
  * This data type is used as a serialized representation of the atom tree.

--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -1,13 +1,11 @@
+import { Argument } from 'core-definitions/definitions-utils';
+
 import { isArray } from '../common/types';
-
-import { Atom, AtomJson, AtomType, NAMED_BRANCHES } from './atom-class';
-
 import { AccentAtom } from '../core-atoms/accent';
 import { ArrayAtom } from '../core-atoms/array';
 import { BoxAtom } from '../core-atoms/box';
 import { CompositionAtom } from '../core-atoms/composition';
-import { ChemAtom } from '../core-definitions/mhchem';
-import { MiddleDelimAtom } from '../core-atoms/delim';
+import { MiddleDelimAtom, SizedDelimAtom } from '../core-atoms/delim';
 import { EncloseAtom } from '../core-atoms/enclose';
 import { ErrorAtom } from '../core-atoms/error';
 import { GenfracAtom } from '../core-atoms/genfrac';
@@ -18,16 +16,16 @@ import { MacroArgumentAtom, MacroAtom } from '../core-atoms/macro';
 import { OperatorAtom } from '../core-atoms/operator';
 import { OverlapAtom } from '../core-atoms/overlap';
 import { OverunderAtom } from '../core-atoms/overunder';
-import { PlaceholderAtom } from '../core-atoms/placeholder';
 import { PhantomAtom } from '../core-atoms/phantom';
-import { SizedDelimAtom } from '../core-atoms/delim';
+import { PlaceholderAtom } from '../core-atoms/placeholder';
+import { PromptAtom } from '../core-atoms/prompt';
 import { SpacingAtom } from '../core-atoms/spacing';
 import { SubsupAtom } from '../core-atoms/subsup';
 import { SurdAtom } from '../core-atoms/surd';
 import { TextAtom } from '../core-atoms/text';
 import { TooltipAtom } from '../core-atoms/tooltip';
-import { PromptAtom } from '../core-atoms/prompt';
-import { Argument } from 'core-definitions/definitions-utils';
+import { ChemAtom } from '../core-definitions/mhchem';
+import { Atom, AtomJson, AtomType, NAMED_BRANCHES } from './atom-class';
 
 export * from './atom-class';
 

--- a/src/core/box.ts
+++ b/src/core/box.ts
@@ -1,13 +1,12 @@
 import { isArray } from '../common/types';
-
-import { getCharacterMetrics } from './font-metrics';
-import { svgBodyToMarkup, svgBodyHeight } from './svg-box';
-import { Context } from './context';
-import { highlight } from './color';
 import { BoxCSSProperties, ParseMode } from '../public/core-types';
-import { Mode } from './modes-utils';
-import { BoxInterface, BoxOptions, BoxType } from './types';
 import { Atom, AtomType } from './atom-class';
+import { highlight } from './color';
+import { Context } from './context';
+import { getCharacterMetrics } from './font-metrics';
+import { Mode } from './modes-utils';
+import { svgBodyHeight, svgBodyToMarkup } from './svg-box';
+import { BoxInterface, BoxOptions, BoxType } from './types';
 
 export function boxType(type: AtomType | undefined): BoxType | undefined {
   if (!type) return undefined;

--- a/src/core/context-utils.ts
+++ b/src/core/context-utils.ts
@@ -2,11 +2,11 @@ import {
   getMacroDefinition,
   getMacros,
 } from '../core-definitions/definitions-utils';
-import type { ContextInterface } from '../core/types';
-
-import { defaultColorMap, defaultBackgroundColorMap } from './color';
+import { defaultBackgroundColorMap, defaultColorMap } from './color';
 import { l10n } from './l10n';
 import { getDefaultRegisters } from './registers';
+
+import type { ContextInterface } from '../core/types';
 
 /** @internal */
 export function getDefaultContext(): ContextInterface {

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -10,10 +10,10 @@ import type {
 } from '../public/core-types';
 import type { ContextInterface, BoxInterface, FontMetrics } from './types';
 
+import { getDefaultContext } from './context-utils';
 import { DEFAULT_FONT_SIZE, FONT_SCALE, PT_PER_EM } from './font-metrics';
 import { D, Dc, Mathstyle, MATHSTYLES } from './mathstyle';
 import { convertDimensionToEm, convertDimensionToPt } from './registers-utils';
-import { getDefaultContext } from './context-utils';
 
 // Using boxes and glue in TeX and LaTeX:
 // https://www.math.utah.edu/~beebe/reports/2009/boxes.pdf

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -1,17 +1,18 @@
 import './atom-class';
-export * from './atom-class';
 import './atom';
-export * from './atom';
 import './context';
-export * from './context';
 import './delimiters';
-export * from './delimiters';
 import './mathstyle';
-export * from './mathstyle';
 import './parser';
-export * from './parser';
 import './box';
-export * from './box';
 import './font-metrics';
-export * from './font-metrics';
 import './modes';
+
+export * from './atom-class';
+export * from './atom';
+export * from './context';
+export * from './delimiters';
+export * from './mathstyle';
+export * from './parser';
+export * from './box';
+export * from './font-metrics';

--- a/src/core/delimiters.ts
+++ b/src/core/delimiters.ts
@@ -22,18 +22,18 @@
  */
 
 import { Box } from './box';
-import { VBoxChild, VBox } from './v-box';
+import { Context } from './context';
 import {
-  getCharacterMetrics,
-  PT_PER_EM,
   AXIS_HEIGHT,
   FONT_SCALE,
   FontName,
+  getCharacterMetrics,
+  PT_PER_EM,
 } from './font-metrics';
-import { Context } from './context';
-import type { MathstyleName, ParseMode, Style } from '../public/core-types';
 import { BoxType } from './types';
+import { VBox, VBoxChild } from './v-box';
 
+import type { MathstyleName, ParseMode, Style } from '../public/core-types';
 export const RIGHT_DELIM = {
   '(': ')',
   '{': '}',

--- a/src/core/l10n.ts
+++ b/src/core/l10n.ts
@@ -1,6 +1,6 @@
+import { isBrowser } from '../common/capabilities';
 // Import { Keys } from '../types-utils';
 import { STRINGS } from '../editor/l10n-strings';
-import { isBrowser } from '../common/capabilities';
 
 interface L10n {
   locale: string;

--- a/src/core/mathstyle.ts
+++ b/src/core/mathstyle.ts
@@ -42,9 +42,9 @@
  */
 
 import { FONT_METRICS } from './font-metrics';
-import type { FontSize } from '../public/core-types';
 import { FontMetrics } from './types';
 
+import type { FontSize } from '../public/core-types';
 // IDs of the different MATHSTYLES
 export const D = 7; // Displaystyle
 export const Dc = 6; // Displaystyle, cramped

--- a/src/core/modes-latex.ts
+++ b/src/core/modes-latex.ts
@@ -1,8 +1,7 @@
+import { LatexAtom } from '../core-atoms/latex';
+import { Atom, ToLatexOptions } from './atom';
 /* eslint-disable no-new */
 import { Mode } from './modes-utils';
-import { Atom, ToLatexOptions } from './atom';
-
-import { LatexAtom } from '../core-atoms/latex';
 
 export class LatexMode extends Mode {
   constructor() {

--- a/src/core/modes-math.ts
+++ b/src/core/modes-math.ts
@@ -1,13 +1,13 @@
+import { mathVariantToUnicode } from '../core-definitions/unicode';
 /* eslint-disable no-new */
 import { Atom, ToLatexOptions } from './atom';
-import { joinLatex, latexCommand } from './tokenizer';
+import { FontName } from './font-metrics';
 import { getPropertyRuns, Mode } from './modes-utils';
+import { joinLatex, latexCommand } from './tokenizer';
+
 import type { Box } from './box';
 import type { Style, Variant, VariantStyle } from '../public/core-types';
-import { mathVariantToUnicode } from '../core-definitions/unicode';
 import type { TokenDefinition } from '../core-definitions/definitions-utils';
-import { FontName } from './font-metrics';
-
 // Each entry indicate the font-name (to be used to calculate font metrics)
 // and the CSS classes (for proper markup styling) for each possible
 // variant combinations.

--- a/src/core/modes-text.ts
+++ b/src/core/modes-text.ts
@@ -1,15 +1,14 @@
 /* eslint-disable no-new */
 
 import { TextAtom } from '../core-atoms/text';
-
+import { TokenDefinition } from '../core-definitions/definitions-utils';
 import { Atom, ToLatexOptions } from './atom';
 import { Box } from './box';
-import { Mode, getPropertyRuns } from './modes-utils';
-import type { FontSeries, FontShape, Style } from '../public/core-types';
-import { joinLatex, latexCommand } from './tokenizer';
-import { TokenDefinition } from '../core-definitions/definitions-utils';
 import { FontName } from './font-metrics';
+import { getPropertyRuns, Mode } from './modes-utils';
+import { joinLatex, latexCommand } from './tokenizer';
 
+import type { FontSeries, FontShape, Style } from '../public/core-types';
 function emitStringTextRun(run: Atom[], options: ToLatexOptions): string[] {
   return run.map((x) => x._serialize(options));
 }

--- a/src/core/modes-utils.ts
+++ b/src/core/modes-utils.ts
@@ -1,4 +1,11 @@
+import {
+  getDefinition,
+  TokenDefinition,
+} from '../core-definitions/definitions-utils';
 import { Atom, ToLatexOptions } from './atom-class';
+import { FontName } from './font-metrics';
+import { joinLatex, latexCommand } from './tokenizer';
+
 import type { Box } from './box';
 import type {
   FontSeries,
@@ -9,13 +16,6 @@ import type {
   Variant,
   VariantStyle,
 } from '../public/core-types';
-import {
-  TokenDefinition,
-  getDefinition,
-} from '../core-definitions/definitions-utils';
-import { joinLatex, latexCommand } from './tokenizer';
-import { FontName } from './font-metrics';
-
 export abstract class Mode {
   static _registry: Record<string, Mode> = {};
   constructor(name: string) {

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -1,25 +1,25 @@
-import { Atom, BBoxParameter } from './atom-class';
-
-import {
-  Argument,
-  FunctionDefinition,
-  argAtoms,
-  getDefinition,
-  getEnvironmentDefinition,
-} from '../core-definitions/definitions-utils';
-import type { ColumnFormat } from '../core-atoms/array';
-
 import { ErrorAtom } from '../core-atoms/error';
 import { GroupAtom } from '../core-atoms/group';
 import { LeftRightAtom } from '../core-atoms/leftright';
 import { MacroAtom } from '../core-atoms/macro';
-import { PromptAtom } from '../core-atoms/prompt';
 import { PlaceholderAtom } from '../core-atoms/placeholder';
+import { PromptAtom } from '../core-atoms/prompt';
 import { SubsupAtom } from '../core-atoms/subsup';
 import { TextAtom } from '../core-atoms/text';
-
+import {
+  argAtoms,
+  Argument,
+  FunctionDefinition,
+  getDefinition,
+  getEnvironmentDefinition,
+} from '../core-definitions/definitions-utils';
+import { Atom, BBoxParameter } from './atom-class';
+import { Context } from './context';
 import { Mode } from './modes-utils';
 import { joinLatex, tokenize, tokensToString } from './tokenizer';
+
+import type { ColumnFormat } from '../core-atoms/array';
+
 import type {
   Style,
   ParseMode,
@@ -34,8 +34,6 @@ import type {
   DimensionUnit,
 } from '../public/core-types';
 import type { ContextInterface, PrivateStyle } from '../core/types';
-import { Context } from './context';
-
 //
 // - Literal (character token): a letter, digit or punctuation
 // - Token: a space `<space>`, a literal, name, group or mode shift

--- a/src/core/registers-utils.ts
+++ b/src/core/registers-utils.ts
@@ -1,4 +1,5 @@
 import { PT_PER_EM } from './font-metrics';
+
 import type { Dimension, Glue, LatexValue } from '../public/core-types';
 
 export function convertDimensionToPt(

--- a/src/core/tokenizer.ts
+++ b/src/core/tokenizer.ts
@@ -6,6 +6,7 @@
  */
 
 import { splitGraphemes } from './grapheme-splitter';
+
 import type { Token } from '../public/core-types';
 
 /**

--- a/src/core/v-box.ts
+++ b/src/core/v-box.ts
@@ -1,8 +1,8 @@
 import { Box } from './box';
 import { Context } from './context';
-import type { Style } from '../public/core-types';
 import { BoxType } from './types';
 
+import type { Style } from '../public/core-types';
 export type VBoxElement = {
   box: Box;
   marginLeft?: number;

--- a/src/editor-mathfield/autocomplete.ts
+++ b/src/editor-mathfield/autocomplete.ts
@@ -1,23 +1,21 @@
 import { LatexAtom } from '../core-atoms/latex';
 import { suggest } from '../core-definitions/definitions-utils';
-
-import type { ModelPrivate } from '../editor-model/model-private';
-
 import {
   hideSuggestionPopover,
   showSuggestionPopover,
 } from '../editor/suggestion-popover';
-
-import type { MathfieldPrivate } from './mathfield-private';
-import { render } from './render';
+import { ParseMode } from '../public/core-types';
+import { ModeEditor } from './mode-editor';
 import {
-  getLatexGroupBody,
   getCommandSuggestionRange,
   getLatexGroup,
+  getLatexGroupBody,
 } from './mode-editor-latex';
-import { ModeEditor } from './mode-editor';
-import { ParseMode } from '../public/core-types';
+import { render } from './render';
 
+import type { ModelPrivate } from '../editor-model/model-private';
+
+import type { MathfieldPrivate } from './mathfield-private';
 export function removeSuggestion(mathfield: MathfieldPrivate): void {
   const group = getLatexGroupBody(mathfield.model).filter(
     (x) => x.isSuggestion

--- a/src/editor-mathfield/commands.ts
+++ b/src/editor-mathfield/commands.ts
@@ -1,12 +1,12 @@
-import { register as registerCommand } from '../editor/commands';
-import type { MathfieldPrivate } from './mathfield-private';
-import { onInput } from './keyboard-input';
-import { toggleKeystrokeCaption } from './keystroke-caption';
 import { contentDidChange, contentWillChange } from '../editor-model/listeners';
-import { requestUpdate } from './render';
+import { register as registerCommand } from '../editor/commands';
 import { ParseMode } from '../public/core-types';
 import { updateAutocomplete } from './autocomplete';
+import { onInput } from './keyboard-input';
+import { toggleKeystrokeCaption } from './keystroke-caption';
+import { requestUpdate } from './render';
 
+import type { MathfieldPrivate } from './mathfield-private';
 registerCommand({
   undo: (mathfield: MathfieldPrivate) => {
     mathfield.undo();

--- a/src/editor-mathfield/keyboard-input.ts
+++ b/src/editor-mathfield/keyboard-input.ts
@@ -1,20 +1,10 @@
 import type { Selector } from '../public/commands';
 
-import { splitGraphemes } from '../core/grapheme-splitter';
+import { LeftRightAtom } from 'core-atoms/leftright';
+import { LEFT_DELIM, RIGHT_DELIM } from 'core/delimiters';
+
 import { Atom } from '../core/atom';
-
-import {
-  keyboardEventToChar,
-  mightProducePrintableCharacter,
-} from '../editor/keyboard';
-import { getInlineShortcut } from '../editor/shortcuts';
-import { getCommandForKeybinding } from '../editor/keybindings';
-import { SelectorPrivate } from '../editor/commands';
-import {
-  getActiveKeyboardLayout,
-  validateKeyboardLayout,
-} from '../editor/keyboard-layout';
-
+import { splitGraphemes } from '../core/grapheme-splitter';
 import { moveAfterParent } from '../editor-model/commands-move';
 import {
   contentDidChange,
@@ -22,18 +12,26 @@ import {
   selectionDidChange,
 } from '../editor-model/listeners';
 import { range } from '../editor-model/selection-utils';
-
+import { SelectorPrivate } from '../editor/commands';
+import { getCommandForKeybinding } from '../editor/keybindings';
+import {
+  keyboardEventToChar,
+  mightProducePrintableCharacter,
+} from '../editor/keyboard';
+import {
+  getActiveKeyboardLayout,
+  validateKeyboardLayout,
+} from '../editor/keyboard-layout';
+import { getInlineShortcut } from '../editor/shortcuts';
 import { removeSuggestion, updateAutocomplete } from './autocomplete';
-import { requestUpdate } from './render';
-import type { MathfieldPrivate } from './mathfield-private';
-import { removeIsolatedSpace, smartMode } from './smartmode';
 import { showKeystroke } from './keystroke-caption';
 import { ModeEditor } from './mode-editor';
+import { requestUpdate } from './render';
+import { removeIsolatedSpace, smartMode } from './smartmode';
+
+import type { MathfieldPrivate } from './mathfield-private';
 import type { ParseMode, Style } from 'public/core-types';
 import type { ModelPrivate } from 'editor-model/model-private';
-import { LeftRightAtom } from 'core-atoms/leftright';
-import { RIGHT_DELIM, LEFT_DELIM } from 'core/delimiters';
-
 /**
  * Handler in response to a keystroke event (or to a virtual keyboard keycap
  * with a `key` property).

--- a/src/editor-mathfield/keystroke-caption.ts
+++ b/src/editor-mathfield/keystroke-caption.ts
@@ -1,12 +1,11 @@
-import { getKeybindingMarkup } from '../editor/keybindings';
-import type { MathfieldPrivate } from './mathfield-private';
-
 import { injectStylesheet, releaseStylesheet } from '../common/stylesheet';
-
+import { getKeybindingMarkup } from '../editor/keybindings';
 import {
   getSharedElement,
   releaseSharedElement,
 } from '../editor/shared-element';
+
+import type { MathfieldPrivate } from './mathfield-private';
 
 export function showKeystroke(
   mathfield: MathfieldPrivate,

--- a/src/editor-mathfield/mode-editor-latex.ts
+++ b/src/editor-mathfield/mode-editor-latex.ts
@@ -1,15 +1,14 @@
-/* eslint-disable no-new */
-import { Offset, Range, InsertOptions } from '../public/mathfield';
 import { LatexAtom, LatexGroupAtom } from '../core-atoms/latex';
-import { range } from '../editor-model/selection-utils';
-import { Atom } from '../core/atom-class';
-import { ModelPrivate } from '../editor-model/model-private';
-import { contentDidChange, contentWillChange } from '../editor-model/listeners';
-
-import { MathfieldPrivate } from './mathfield-private';
-import { requestUpdate } from './render';
-import { ModeEditor } from './mode-editor';
 import { COMMAND_MODE_CHARACTERS } from '../core-definitions/definitions-utils';
+import { Atom } from '../core/atom-class';
+import { contentDidChange, contentWillChange } from '../editor-model/listeners';
+import { ModelPrivate } from '../editor-model/model-private';
+import { range } from '../editor-model/selection-utils';
+/* eslint-disable no-new */
+import { InsertOptions, Offset, Range } from '../public/mathfield';
+import { MathfieldPrivate } from './mathfield-private';
+import { ModeEditor } from './mode-editor';
+import { requestUpdate } from './render';
 
 export class LatexModeEditor extends ModeEditor {
   constructor() {

--- a/src/editor-mathfield/mode-editor-math.ts
+++ b/src/editor-mathfield/mode-editor-math.ts
@@ -2,28 +2,24 @@
 
 import type { Expression } from '@cortex-js/compute-engine/dist/types/math-json/math-json-format';
 
-import { InsertOptions, Offset, OutputFormat } from '../public/mathfield';
-
-import { requestUpdate } from './render';
-
-import { LEFT_DELIM } from '../core/delimiters';
-import { parseLatex } from '../core/parser';
-import { fromJson } from '../core/atom';
-import { Atom, AtomJson } from '../core/atom-class';
 import { ArrayAtom } from '../core-atoms/array';
 import { LeftRightAtom } from '../core-atoms/leftright';
-
-import { range } from '../editor-model/selection-utils';
-import { ModelPrivate } from '../editor-model/model-private';
-import { applyStyleToUnstyledAtoms } from '../editor-model/styling';
+import { fromJson } from '../core/atom';
+import { Atom, AtomJson } from '../core/atom-class';
+import { LEFT_DELIM } from '../core/delimiters';
+import { parseLatex } from '../core/parser';
 import { contentDidChange, contentWillChange } from '../editor-model/listeners';
+import { ModelPrivate } from '../editor-model/model-private';
+import { range } from '../editor-model/selection-utils';
+import { applyStyleToUnstyledAtoms } from '../editor-model/styling';
 import {
   parseMathString,
   trimModeShiftCommand,
 } from '../editor/parse-math-string';
-
+import { InsertOptions, Offset, OutputFormat } from '../public/mathfield';
 import { MathfieldPrivate } from './mathfield-private';
 import { ModeEditor } from './mode-editor';
+import { requestUpdate } from './render';
 
 export class MathModeEditor extends ModeEditor {
   constructor() {

--- a/src/editor-mathfield/mode-editor-text.ts
+++ b/src/editor-mathfield/mode-editor-text.ts
@@ -1,17 +1,17 @@
 /* eslint-disable no-new */
 import type { InsertOptions } from '../public/mathfield';
 
-import { parseLatex } from '../core/core';
+import { ContextInterface } from 'core/types';
+
 import { Atom } from '../core/atom-class';
+import { parseLatex } from '../core/core';
+import { contentDidChange, contentWillChange } from '../editor-model/listeners';
 import { ModelPrivate } from '../editor-model/model-private';
 import { range } from '../editor-model/selection-utils';
 import { applyStyleToUnstyledAtoms } from '../editor-model/styling';
-import { contentDidChange, contentWillChange } from '../editor-model/listeners';
-
 import { MathfieldPrivate } from './mathfield-private';
 import { ModeEditor } from './mode-editor';
 import { requestUpdate } from './render';
-import { ContextInterface } from 'core/types';
 
 export class TextModeEditor extends ModeEditor {
   constructor() {

--- a/src/editor-mathfield/pointer-input.ts
+++ b/src/editor-mathfield/pointer-input.ts
@@ -1,11 +1,11 @@
-import { on, off, getAtomBounds, Rect } from './utils';
-import type { MathfieldPrivate } from './mathfield-private';
-import { requestUpdate } from './render';
-import { Offset } from '../public/mathfield';
 import { Atom } from '../core/atom-class';
-import { acceptCommandSuggestion } from './autocomplete';
 import { selectGroup } from '../editor-model/commands-select';
+import { Offset } from '../public/mathfield';
+import { acceptCommandSuggestion } from './autocomplete';
+import { requestUpdate } from './render';
+import { getAtomBounds, off, on, Rect } from './utils';
 
+import type { MathfieldPrivate } from './mathfield-private';
 let gLastTap: { x: number; y: number; time: number } | null = null;
 let gTapCount = 0;
 

--- a/src/editor-mathfield/render.ts
+++ b/src/editor-mathfield/render.ts
@@ -1,19 +1,19 @@
-import { Box, makeStruts } from '../core/box';
+import { Atom } from 'core/atom-class';
+import { Context } from 'core/context';
 
+import { Box, makeStruts } from '../core/box';
+import { gFontsState } from '../core/fonts';
+import { applyInterBoxSpacing } from '../core/inter-box-spacing';
+import { updateSuggestionPopoverPosition } from '../editor/suggestion-popover';
 import {
-  Rect,
+  adjustForScrolling,
+  getAtomBounds,
   getSelectionBounds,
   isValidMathfield,
-  getAtomBounds,
-  adjustForScrolling,
+  Rect,
 } from './utils';
-import type { MathfieldPrivate } from './mathfield-private';
 
-import { updateSuggestionPopoverPosition } from '../editor/suggestion-popover';
-import { gFontsState } from '../core/fonts';
-import { Context } from 'core/context';
-import { Atom } from 'core/atom-class';
-import { applyInterBoxSpacing } from '../core/inter-box-spacing';
+import type { MathfieldPrivate } from './mathfield-private';
 
 /*
  * Return a hash (32-bit integer) representing the content of the mathfield

--- a/src/editor-mathfield/smartmode.ts
+++ b/src/editor-mathfield/smartmode.ts
@@ -1,14 +1,14 @@
+import { LeftRightAtom } from '../core-atoms/leftright';
+import { Atom } from '../core/atom-class';
+import { joinLatex } from '../core/tokenizer';
+import { contentDidChange } from '../editor-model/listeners';
+import { ModelPrivate } from '../editor-model/model-private';
 import {
   keyboardEventToChar,
   mightProducePrintableCharacter,
 } from '../editor/keyboard';
-import { contentDidChange } from '../editor-model/listeners';
-import type { MathfieldPrivate } from './mathfield-private';
 
-import { ModelPrivate } from '../editor-model/model-private';
-import { Atom } from '../core/atom-class';
-import { LeftRightAtom } from '../core-atoms/leftright';
-import { joinLatex } from '../core/tokenizer';
+import type { MathfieldPrivate } from './mathfield-private';
 
 /**
  * Convert the atoms before the anchor to 'text' mode

--- a/src/editor-mathfield/styling.ts
+++ b/src/editor-mathfield/styling.ts
@@ -1,6 +1,8 @@
-import { MathfieldPrivate } from './mathfield-private';
+import { PrivateStyle } from '../core/types';
 import { applyStyle as applyStyleToModel } from '../editor-model/styling';
 import { register as registerCommand } from '../editor/commands';
+import { MathfieldPrivate } from './mathfield-private';
+
 import type {
   Style,
   FontSeries,
@@ -8,8 +10,6 @@ import type {
   FontSize,
   FontFamily,
 } from '../public/core-types';
-import { PrivateStyle } from '../core/types';
-
 export function applyStyle(
   mathfield: MathfieldPrivate,
   inStyle: Style

--- a/src/editor-mathfield/utils.ts
+++ b/src/editor-mathfield/utils.ts
@@ -1,8 +1,8 @@
 import { Atom } from '../core/atom-class';
-import type { Range } from '../public/mathfield';
 import { OriginValidator } from '../public/options';
 import { MathfieldPrivate } from './mathfield-private';
 
+import type { Range } from '../public/mathfield';
 export type Rect = {
   top: number;
   bottom: number;

--- a/src/editor-model/array-utils.ts
+++ b/src/editor-model/array-utils.ts
@@ -1,5 +1,4 @@
 import { isArray } from '../common/types';
-
 import { Atom } from '../core/atom';
 
 /**

--- a/src/editor-model/array.ts
+++ b/src/editor-model/array.ts
@@ -1,16 +1,15 @@
+import { ArrayAtom } from '../core-atoms/array';
+import { LeftRightAtom } from '../core-atoms/leftright';
+import { PlaceholderAtom } from '../core-atoms/placeholder';
+import { makeEnvironment } from '../core-definitions/environments';
 import { Atom } from '../core/atom';
-
 import { register as registerCommand } from '../editor/commands';
+import { Environment, TabularEnvironment } from '../public/core-types';
+import { arrayCell, arrayIndex } from './array-utils';
+import { contentDidChange, contentWillChange } from './listeners';
 
 import type { ModelPrivate } from './model-private';
-import { contentDidChange, contentWillChange } from './listeners';
-import { arrayIndex, arrayCell } from './array-utils';
-import { ArrayAtom } from '../core-atoms/array';
 import type { Style } from '../public/core-types';
-import { Environment, TabularEnvironment } from '../public/core-types';
-import { makeEnvironment } from '../core-definitions/environments';
-import { PlaceholderAtom } from '../core-atoms/placeholder';
-import { LeftRightAtom } from '../core-atoms/leftright';
 export * from './array-utils';
 
 /**

--- a/src/editor-model/commands-delete.ts
+++ b/src/editor-model/commands-delete.ts
@@ -1,9 +1,9 @@
 import { register } from '../editor/commands';
-import type { ModelPrivate } from './model-private';
-import { deleteForward, deleteBackward, deleteRange } from './delete';
 import { wordBoundaryOffset } from './commands';
+import { deleteBackward, deleteForward, deleteRange } from './delete';
 import { contentWillChange } from './listeners';
 
+import type { ModelPrivate } from './model-private';
 register(
   {
     deleteAll: (model: ModelPrivate): boolean =>

--- a/src/editor-model/commands-move.ts
+++ b/src/editor-model/commands-move.ts
@@ -1,10 +1,9 @@
 import { isBrowser } from '../common/capabilities';
-
-import { Atom, BranchName } from '../core/atom';
 import { SubsupAtom } from '../core-atoms/subsup';
+import { Atom, BranchName } from '../core/atom';
 import { register } from '../editor/commands';
-
 import { move, skip } from './commands';
+
 import type { ModelPrivate } from './model-private';
 
 export function moveAfterParent(model: ModelPrivate): boolean {

--- a/src/editor-model/commands-select.ts
+++ b/src/editor-model/commands-select.ts
@@ -1,10 +1,10 @@
-import { register } from '../editor/commands';
-import type { ModelPrivate } from './model-private';
 import { LETTER_AND_DIGITS } from '../core-definitions/definitions-utils';
-import { getMode } from './selection';
+import { register } from '../editor/commands';
 import { move, skip } from './commands';
+import { getMode } from './selection';
 import { range } from './selection-utils';
 
+import type { ModelPrivate } from './model-private';
 /**
  * Select all the atoms in the current group, that is all the siblings.
  * When the selection is in a numerator, the group is the numerator. When

--- a/src/editor-model/commands.ts
+++ b/src/editor-model/commands.ts
@@ -1,14 +1,14 @@
 import type { ModelPrivate } from './model-private';
-import { MathfieldPrivate, getLocalDOMRect } from '../editor/mathfield';
-import { Atom } from '../core/atom-class';
 import { ArrayAtom } from '../core-atoms/array';
 import { LatexAtom } from '../core-atoms/latex';
+import { PromptAtom } from '../core-atoms/prompt';
 import { TextAtom } from '../core-atoms/text';
 import { LETTER_AND_DIGITS } from '../core-definitions/definitions-utils';
-import type { Offset, Selection } from '../public/mathfield';
+import { Atom } from '../core/atom-class';
 import { getCommandSuggestionRange } from '../editor-mathfield/mode-editor-latex';
-import { PromptAtom } from '../core-atoms/prompt';
+import { getLocalDOMRect, MathfieldPrivate } from '../editor/mathfield';
 
+import type { Offset, Selection } from '../public/mathfield';
 /*
  * Calculates the offset of the "next word".
  * This is inspired by the behavior of text editors on macOS, namely:

--- a/src/editor-model/composition.ts
+++ b/src/editor-model/composition.ts
@@ -1,5 +1,5 @@
-import { ModelPrivate } from './model-private';
 import { CompositionAtom } from '../core-atoms/composition';
+import { ModelPrivate } from './model-private';
 
 /**
  * Create, remove or update a composition atom at the current location

--- a/src/editor-model/delete.ts
+++ b/src/editor-model/delete.ts
@@ -1,12 +1,14 @@
-import { ContentChangeType } from '../public/options';
-import type { Range } from '../public/mathfield';
+import MathfieldElement from 'public/mathfield-element';
 
 import { LeftRightAtom } from '../core-atoms/leftright';
 import { Atom, Branch } from '../core/atom';
+import { ContentChangeType } from '../public/options';
+import { contentWillChange } from './listeners';
 import { ModelPrivate } from './model-private';
 import { range } from './selection-utils';
-import { contentWillChange } from './listeners';
-import MathfieldElement from 'public/mathfield-element';
+
+import type { Range } from '../public/mathfield';
+
 // import {
 //     arrayFirstCellByRow,
 //     arrayColRow,

--- a/src/editor-model/listeners.ts
+++ b/src/editor-model/listeners.ts
@@ -1,7 +1,8 @@
-import { ContentChangeOptions } from '../public/options';
-import { ModelPrivate } from './model-private';
 import '../virtual-keyboard/global';
+
+import { ContentChangeOptions } from '../public/options';
 import { makeProxy } from '../virtual-keyboard/mathfield-proxy';
+import { ModelPrivate } from './model-private';
 
 export type ModelListeners = {
   onSelectionDidChange: () => void;

--- a/src/editor-model/model-private.ts
+++ b/src/editor-model/model-private.ts
@@ -14,27 +14,24 @@ import type { ParseMode } from '../public/core-types';
 
 import type { MathfieldPrivate } from '../editor-mathfield/mathfield-private';
 
+import { toMathML } from '../addons/math-ml';
+import { LatexAtom } from '../core-atoms/latex';
+import { AtomJson, BranchName, fromJson } from '../core/atom';
 import { Atom, ToLatexOptions } from '../core/atom-class';
 import { joinLatex } from '../core/tokenizer';
-import { AtomJson, BranchName, fromJson } from '../core/atom';
-
-import { toMathML } from '../addons/math-ml';
-
+import { defaultAnnounceHook } from '../editor/a11y';
 import { atomToAsciiMath } from '../editor/atom-to-ascii-math';
 import { atomToSpeakableText } from '../editor/atom-to-speakable-text';
-import { defaultAnnounceHook } from '../editor/a11y';
-
 import {
   contentDidChange,
   contentWillChange,
   ModelListeners,
   selectionDidChange,
 } from './listeners';
-import { isOffset, isSelection, isRange, AnnounceVerb } from './utils';
 import { compareSelection, range } from './selection-utils';
-import type { ArrayAtom } from '../core-atoms/array';
-import { LatexAtom } from '../core-atoms/latex';
+import { AnnounceVerb, isOffset, isRange, isSelection } from './utils';
 
+import type { ArrayAtom } from '../core-atoms/array';
 export type ModelState = {
   content: AtomJson;
   selection: Selection;

--- a/src/editor-model/selection.ts
+++ b/src/editor-model/selection.ts
@@ -1,6 +1,5 @@
 import { ParseMode } from '../public/core-types';
 import { Offset } from '../public/mathfield';
-
 import { ModelPrivate } from './model-private';
 
 export function getMode(

--- a/src/editor-model/styling.ts
+++ b/src/editor-model/styling.ts
@@ -1,11 +1,11 @@
-import { Atom } from '../core/atom';
-import type { ModelPrivate } from './model-private';
-import { Range } from '../public/mathfield';
 import { isArray } from '../common/types';
+import { Atom } from '../core/atom';
 import { DEFAULT_FONT_SIZE } from '../core/font-metrics';
-import type { Style } from '../public/core-types';
 import { PrivateStyle } from '../core/types';
+import { Range } from '../public/mathfield';
 
+import type { ModelPrivate } from './model-private';
+import type { Style } from '../public/core-types';
 export function applyStyleToUnstyledAtoms(
   atom: Atom | Atom[] | undefined,
   style?: Style

--- a/src/editor/a11y.ts
+++ b/src/editor/a11y.ts
@@ -1,11 +1,9 @@
 import { Atom } from '../core/atom';
+import { AnnounceVerb } from '../editor-model/utils';
+import { speakableText } from './speech';
 
 import type { ModelPrivate } from '../editor-model/model-private';
 import type { MathfieldPrivate } from '../editor-mathfield/mathfield-private';
-import { AnnounceVerb } from '../editor-model/utils';
-
-import { speakableText } from './speech';
-
 /**
  * Given an atom, describe the relationship between the atom
  * and its siblings and their parent.

--- a/src/editor/atom-to-ascii-math.ts
+++ b/src/editor/atom-to-ascii-math.ts
@@ -1,10 +1,9 @@
 import { isArray } from '../common/types';
-
-import type { Atom } from '../core/atom';
+import { ArrayAtom } from '../core-atoms/array';
 import { GenfracAtom } from '../core-atoms/genfrac';
 import { LeftRightAtom } from '../core-atoms/leftright';
-import { ArrayAtom } from '../core-atoms/array';
 
+import type { Atom } from '../core/atom';
 const SPECIAL_IDENTIFIERS = {
   '\\ne': '≠',
   '\\neq': '≠',

--- a/src/editor/atom-to-speakable-text.ts
+++ b/src/editor/atom-to-speakable-text.ts
@@ -1,12 +1,11 @@
-import { Atom } from '../core/atom';
-
 import { toMathML } from '../addons/math-ml';
-import { LeftRightAtom } from '../core-atoms/leftright';
-import { isArray } from '../common/types';
 import { osPlatform } from '../common/capabilities';
+import { isArray } from '../common/types';
 import { ArrayAtom } from '../core-atoms/array';
-import { getMacros } from '../core-definitions/definitions-utils';
+import { LeftRightAtom } from '../core-atoms/leftright';
 import { PromptAtom } from '../core-atoms/prompt';
+import { getMacros } from '../core-definitions/definitions-utils';
+import { Atom } from '../core/atom';
 
 declare global {
   interface Window {

--- a/src/editor/commands.ts
+++ b/src/editor/commands.ts
@@ -1,17 +1,15 @@
+import { canVibrate } from '../common/capabilities';
 import { isArray } from '../common/types';
-
-import { SelectorPrivate, CommandRegistry } from './types';
-
-import type { MathfieldPrivate } from '../editor-mathfield/mathfield-private';
-import { requestUpdate } from '../editor-mathfield/render';
 import {
-  updateAutocomplete,
   complete,
   removeSuggestion,
+  updateAutocomplete,
 } from '../editor-mathfield/autocomplete';
-import { canVibrate } from '../common/capabilities';
+import { requestUpdate } from '../editor-mathfield/render';
 import MathfieldElement from '../public/mathfield-element';
+import { CommandRegistry, SelectorPrivate } from './types';
 
+import type { MathfieldPrivate } from '../editor-mathfield/mathfield-private';
 export { SelectorPrivate };
 
 // @revisit: move to mathfield.vibrate()

--- a/src/editor/environment-popover.ts
+++ b/src/editor/environment-popover.ts
@@ -1,15 +1,14 @@
-import { CasesEnvironment, MatrixEnvironment } from '../public/core-types';
+import { injectStylesheet, releaseStylesheet } from '../common/stylesheet';
 import {
   isAlignEnvironment,
   isCasesEnvironment,
   isMatrixEnvironment,
   isTabularEnvironment,
 } from '../core-definitions/environment-types';
-import { SelectorPrivate } from './types';
+import { CasesEnvironment, MatrixEnvironment } from '../public/core-types';
 import { MathfieldPrivate } from './mathfield';
 import { getSharedElement, releaseSharedElement } from './shared-element';
-
-import { injectStylesheet, releaseStylesheet } from '../common/stylesheet';
+import { SelectorPrivate } from './types';
 
 const padding = 4;
 const radius = 20;

--- a/src/editor/keybindings-definitions.ts
+++ b/src/editor/keybindings-definitions.ts
@@ -1,4 +1,5 @@
 import { Selector } from '../public/commands';
+
 import type { Keybinding } from '../public/options';
 
 export const DEFAULT_KEYBINDINGS: Keybinding[] = [

--- a/src/editor/keybindings.ts
+++ b/src/editor/keybindings.ts
@@ -1,17 +1,16 @@
+import { isBrowser, osPlatform } from '../common/capabilities';
 import { isArray } from '../common/types';
-
-import type { Selector } from '../public/commands';
-import type { Keybinding } from '../public/options';
-
+import { ParseMode } from '../public/core-types';
+import { REVERSE_KEYBINDINGS } from './keybindings-definitions';
 import {
-  KeyboardLayout,
   getCodeForKey,
+  KeyboardLayout,
   keystrokeModifiersFromString,
   keystrokeModifiersToString,
 } from './keyboard-layout';
-import { REVERSE_KEYBINDINGS } from './keybindings-definitions';
-import { isBrowser, osPlatform } from '../common/capabilities';
-import { ParseMode } from '../public/core-types';
+
+import type { Selector } from '../public/commands';
+import type { Keybinding } from '../public/options';
 
 /**
  * @param p The platform to test against.

--- a/src/editor/keyboard-layout.ts
+++ b/src/editor/keyboard-layout.ts
@@ -1,4 +1,5 @@
 import { osPlatform } from '../common/capabilities';
+
 import type { KeyboardLayoutName as KeyboardLayoutId } from '../public/options';
 
 type KeystrokeModifiers = {

--- a/src/editor/options.ts
+++ b/src/editor/options.ts
@@ -1,18 +1,13 @@
 import type { MathfieldOptions } from '../public/options';
-import { VirtualKeyboardPolicy } from '../public/mathfield-element';
-
 import { isArray } from '../common/types';
-
-import { l10n } from '../core/l10n';
-import { defaultBackgroundColorMap, defaultColorMap } from '../core/color';
-
 import { normalizeMacroDictionary } from '../core-definitions/definitions-utils';
-
+import { defaultBackgroundColorMap, defaultColorMap } from '../core/color';
+import { l10n } from '../core/l10n';
 import { defaultExportHook } from '../editor-mathfield/mode-editor';
-
-import { INLINE_SHORTCUTS } from './shortcuts-definitions';
-import { DEFAULT_KEYBINDINGS } from './keybindings-definitions';
+import { VirtualKeyboardPolicy } from '../public/mathfield-element';
 import { VirtualKeyboard } from '../virtual-keyboard/global';
+import { DEFAULT_KEYBINDINGS } from './keybindings-definitions';
+import { INLINE_SHORTCUTS } from './shortcuts-definitions';
 
 /** @internal */
 export type _MathfieldOptions = MathfieldOptions & {

--- a/src/editor/parse-math-string.ts
+++ b/src/editor/parse-math-string.ts
@@ -1,5 +1,5 @@
 import { OutputFormat } from '../public/mathfield';
-import { InlineShortcutDefinitions, getInlineShortcut } from './shortcuts';
+import { getInlineShortcut, InlineShortcutDefinitions } from './shortcuts';
 import { INLINE_SHORTCUTS } from './shortcuts-definitions';
 
 /**

--- a/src/editor/shortcuts.ts
+++ b/src/editor/shortcuts.ts
@@ -3,6 +3,7 @@ import type {
   InlineShortcutDefinitions,
 } from '../public/options';
 import { LETTER } from '../core-definitions/definitions-utils';
+
 import type { Atom } from '../core/atom';
 
 export { InlineShortcutDefinition, InlineShortcutDefinitions };

--- a/src/editor/speech-read-aloud.ts
+++ b/src/editor/speech-read-aloud.ts
@@ -1,6 +1,6 @@
-import { globalMathLive } from '../mathlive';
 import { isBrowser } from '../common/capabilities';
 import { render } from '../editor-mathfield/render';
+import { globalMathLive } from '../mathlive';
 
 function removeHighlight(element: Element | null): void {
   if (!element) return;

--- a/src/editor/speech.ts
+++ b/src/editor/speech.ts
@@ -4,11 +4,11 @@ import type { Atom } from '../core/atom';
 
 import type { MathfieldPrivate } from '../editor-mathfield/mathfield-private';
 
+import { isBrowser } from '../common/capabilities';
+import { render } from '../editor-mathfield/render';
+import { globalMathLive } from '../mathlive';
 import { atomToSpeakableText } from './atom-to-speakable-text';
 import { register as registerCommand } from './commands';
-import { render } from '../editor-mathfield/render';
-import { isBrowser } from '../common/capabilities';
-import { globalMathLive } from '../mathlive';
 
 declare global {
   interface Window {

--- a/src/editor/suggestion-popover.ts
+++ b/src/editor/suggestion-popover.ts
@@ -1,23 +1,20 @@
 import { injectStylesheet, releaseStylesheet } from '../common/stylesheet';
-
 import {
+  Atom,
+  Box,
+  coalesce,
+  Context,
   makeStruts,
   parseLatex,
-  Atom,
-  coalesce,
-  Box,
-  Context,
 } from '../core/core';
-
-import { getCaretPoint } from '../editor-mathfield/utils';
-import type { MathfieldPrivate } from '../editor-mathfield/mathfield-private';
-
-import { getKeybindingsForCommand } from './keybindings';
-
+import { applyInterBoxSpacing } from '../core/inter-box-spacing';
 import { complete } from '../editor-mathfield/autocomplete';
 import { ModeEditor } from '../editor-mathfield/mode-editor';
-import { applyInterBoxSpacing } from '../core/inter-box-spacing';
+import { getCaretPoint } from '../editor-mathfield/utils';
+import { getKeybindingsForCommand } from './keybindings';
 import { getSharedElement, releaseSharedElement } from './shared-element';
+
+import type { MathfieldPrivate } from '../editor-mathfield/mathfield-private';
 
 function latexToMarkup(mf: MathfieldPrivate, latex: string): string {
   const context = new Context({ from: mf.context });

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -1,6 +1,6 @@
+import { Selector } from '../public/commands';
 import { Keys } from '../public/types-utils';
 
-import { Selector } from '../public/commands';
 import type { VirtualKeyboardCommands } from '../public/virtual-keyboard';
 
 export type SelectorPrivate = Selector | Keys<VirtualKeyboardCommands>;

--- a/src/mathlive.ts
+++ b/src/mathlive.ts
@@ -2,20 +2,21 @@
 import type { AutoRenderOptions } from './public/options';
 export * from './public/mathlive';
 
-import {
-  AutoRenderOptionsPrivate,
-  autoRenderMathInElement,
-} from './addons/auto-render';
-export * from './addons/auto-render';
-
 import './virtual-keyboard/commands';
 
+import {
+  autoRenderMathInElement,
+  AutoRenderOptionsPrivate,
+} from './addons/auto-render';
 import {
   convertLatexToMarkup,
   convertLatexToMathMl,
   convertLatexToSpeakableText,
   serializeMathJsonToLatex,
 } from './public/mathlive-ssr';
+
+export * from './addons/auto-render';
+
 import type { VirtualKeyboardInterface } from './public/virtual-keyboard';
 
 export type MathLiveGlobal = {

--- a/src/public/mathfield-element.ts
+++ b/src/public/mathfield-element.ts
@@ -20,26 +20,27 @@ import type {
   MathfieldOptions,
 } from './options';
 
+import { getStylesheet, getStylesheetContent } from 'common/stylesheet';
+import { Scrim } from 'editor/scrim';
+
+import { isBrowser } from '../common/capabilities';
+import { resolveUrl } from '../common/script-url';
+import { loadFonts, reloadFonts } from '../core/fonts';
+import { l10n } from '../core/l10n';
+import { MathfieldPrivate } from '../editor-mathfield/mathfield-private';
+import { offsetFromPoint } from '../editor-mathfield/pointer-input';
+import { requestUpdate } from '../editor-mathfield/render';
+import { getAtomBounds } from '../editor-mathfield/utils';
+import { isOffset, isRange, isSelection } from '../editor/model';
 import {
   get as getOptions,
   getDefault as getDefaultOptions,
   update as updateOptions,
 } from '../editor/options';
-import { isOffset, isRange, isSelection } from '../editor/model';
-import { MathfieldPrivate } from '../editor-mathfield/mathfield-private';
-import { offsetFromPoint } from '../editor-mathfield/pointer-input';
-import { getAtomBounds } from '../editor-mathfield/utils';
-import { isBrowser } from '../common/capabilities';
-import { resolveUrl } from '../common/script-url';
-import { requestUpdate } from '../editor-mathfield/render';
-import { reloadFonts, loadFonts } from '../core/fonts';
 import { defaultSpeakHook } from '../editor/speech';
 import { defaultReadAloudHook } from '../editor/speech-read-aloud';
-import type { ComputeEngine } from '@cortex-js/compute-engine';
 
-import { l10n } from '../core/l10n';
-import { getStylesheet, getStylesheetContent } from 'common/stylesheet';
-import { Scrim } from 'editor/scrim';
+import type { ComputeEngine } from '@cortex-js/compute-engine';
 
 export declare type Expression =
   | number

--- a/src/public/mathlive-ssr.ts
+++ b/src/public/mathlive-ssr.ts
@@ -6,30 +6,29 @@
  *
  */
 
-import { Atom } from '../core/atom-class';
-
 import '../core-definitions/definitions';
+import '../core/modes';
+
+import { toMathML } from '../addons/math-ml';
+import { Atom } from '../core/atom-class';
+import { Box, coalesce, makeStruts } from '../core/box';
+import { Context } from '../core/context';
+import { getDefaultContext } from '../core/context-utils';
+import { applyInterBoxSpacing } from '../core/inter-box-spacing';
+import {
+  parseLatex,
+  validateLatex as validateLatexInternal,
+} from '../core/parser';
+import { atomToAsciiMath } from '../editor/atom-to-ascii-math';
+import { atomToSpeakableText } from '../editor/atom-to-speakable-text';
+import { parseMathString } from '../editor/parse-math-string';
+import { Expression } from './mathfield-element';
 
 import type {
   ComputeEngine,
   SemiBoxedExpression,
 } from '@cortex-js/compute-engine';
-import { toMathML } from '../addons/math-ml';
-import { Box, coalesce, makeStruts } from '../core/box';
-import { Context } from '../core/context';
-import { parseLatex } from '../core/parser';
-import { atomToSpeakableText } from '../editor/atom-to-speakable-text';
-import { Expression } from './mathfield-element';
-import { validateLatex as validateLatexInternal } from '../core/parser';
-
-import { atomToAsciiMath } from '../editor/atom-to-ascii-math';
-import { parseMathString } from '../editor/parse-math-string';
-
 import type { LatexSyntaxError, ParseMode } from './core-types';
-
-import '../core/modes';
-import { getDefaultContext } from '../core/context-utils';
-import { applyInterBoxSpacing } from '../core/inter-box-spacing';
 
 /**
  * Convert a LaTeX string to a string of HTML markup.

--- a/src/virtual-keyboard/commands.ts
+++ b/src/virtual-keyboard/commands.ts
@@ -1,5 +1,4 @@
 import { register } from '../editor/commands';
-
 import { hideVariantsPanel } from './variants';
 import { VirtualKeyboard } from './virtual-keyboard';
 

--- a/src/virtual-keyboard/global.ts
+++ b/src/virtual-keyboard/global.ts
@@ -1,6 +1,6 @@
 import { isBrowser } from '../common/capabilities';
-import { VirtualKeyboard } from './virtual-keyboard';
 import { VirtualKeyboardProxy } from './proxy';
+import { VirtualKeyboard } from './virtual-keyboard';
 
 export { VirtualKeyboard } from './virtual-keyboard';
 export { VirtualKeyboardProxy } from './proxy';

--- a/src/virtual-keyboard/proxy.ts
+++ b/src/virtual-keyboard/proxy.ts
@@ -1,3 +1,6 @@
+import { validateOrigin } from '../editor-mathfield/utils';
+import { getCommandTarget } from '../editor/commands';
+import { OriginValidator } from '../public/options';
 import {
   AlphabeticKeyboardLayout,
   EditToolbarOptions,
@@ -5,9 +8,7 @@ import {
   VirtualKeyboardLayout,
   VirtualKeyboardName,
 } from '../public/virtual-keyboard';
-import { validateOrigin } from '../editor-mathfield/utils';
-import { getCommandTarget } from '../editor/commands';
-import { OriginValidator } from '../public/options';
+
 import type {
   VirtualKeyboardMessage,
   VirtualKeyboardInterface,

--- a/src/virtual-keyboard/utils.ts
+++ b/src/virtual-keyboard/utils.ts
@@ -1,19 +1,15 @@
+import { injectStylesheet, releaseStylesheet } from '../common/stylesheet';
 import { Atom } from '../core/atom';
-import { coalesce, Box, makeStruts } from '../core/box';
+import { Box, coalesce, makeStruts } from '../core/box';
+import { Context } from '../core/context';
+import { loadFonts } from '../core/fonts';
+import { applyInterBoxSpacing } from '../core/inter-box-spacing';
 import { l10n as l10nOptions, localize as l10n } from '../core/l10n';
 import { parseLatex } from '../core/parser';
-import { SelectorPrivate } from '../editor/types';
 import { getActiveKeyboardLayout } from '../editor/keyboard-layout';
-
-import { releaseStylesheet, injectStylesheet } from '../common/stylesheet';
-import { loadFonts } from '../core/fonts';
-import { Context } from '../core/context';
-
-import { LAYOUTS } from './data';
-import { VirtualKeyboard } from './virtual-keyboard';
-import { MathfieldProxy } from '../public/virtual-keyboard';
-import { hasVariants, showVariantsPanel } from './variants';
+import { SelectorPrivate } from '../editor/types';
 import {
+  MathfieldProxy,
   NormalizedVirtualKeyboardLayer,
   NormalizedVirtualKeyboardLayout,
   VirtualKeyboardKeycap,
@@ -21,7 +17,9 @@ import {
   VirtualKeyboardLayout,
   VirtualKeyboardOptions,
 } from '../public/virtual-keyboard';
-import { applyInterBoxSpacing } from '../core/inter-box-spacing';
+import { LAYOUTS } from './data';
+import { hasVariants, showVariantsPanel } from './variants';
+import { VirtualKeyboard } from './virtual-keyboard';
 
 function jsonToCssProps(json) {
   if (typeof json === 'string') return json;

--- a/src/virtual-keyboard/variants.ts
+++ b/src/virtual-keyboard/variants.ts
@@ -1,4 +1,6 @@
+import { BACKGROUND_COLORS, FOREGROUND_COLORS } from '../core/color';
 import { Scrim } from '../editor/scrim';
+import MathfieldElement from '../public/mathfield-element';
 import {
   executeKeycapCommand,
   normalizeKeycap,
@@ -6,8 +8,7 @@ import {
   renderKeycap,
 } from './utils';
 import { VirtualKeyboard } from './virtual-keyboard';
-import { FOREGROUND_COLORS, BACKGROUND_COLORS } from '../core/color';
-import MathfieldElement from '../public/mathfield-element';
+
 import type { VirtualKeyboardKeycap } from '../public/virtual-keyboard';
 
 const VARIANTS: {

--- a/src/virtual-keyboard/virtual-keyboard.ts
+++ b/src/virtual-keyboard/virtual-keyboard.ts
@@ -20,20 +20,18 @@ import type { MathfieldElement } from '../public/mathfield-element';
 import { isTouchCapable } from '../common/capabilities';
 import { isArray } from '../common/types';
 import { validateOrigin } from '../editor-mathfield/utils';
-import { getCommandTarget, COMMANDS } from '../editor/commands';
+import { COMMANDS, getCommandTarget } from '../editor/commands';
 import { SelectorPrivate } from '../editor/types';
-
+import { Style } from '../public/core-types';
 import { isVirtualKeyboardMessage, VIRTUAL_KEYBOARD_MESSAGE } from './proxy';
 import {
-  makeKeyboardElement,
   makeEditToolbar,
-  releaseStylesheets,
+  makeKeyboardElement,
   normalizeLayout,
+  releaseStylesheets,
   renderKeycap,
 } from './utils';
-
 import { hideVariantsPanel, showVariantsPanel } from './variants';
-import { Style } from '../public/core-types';
 
 export class VirtualKeyboard implements VirtualKeyboardInterface, EventTarget {
   private _visible: boolean;


### PR DESCRIPTION
Sorted using [TypeScript Import Sorter](https://marketplace.visualstudio.com/items?itemName=mike-co.import-sorter) VS Code extension.

Totally OCD, but feel free to merge it if you want to.