### PR TITLE
fix: virtual-keyboard keycap hover color variable

### DIFF
--- a/css/virtual-keyboard.less
+++ b/css/virtual-keyboard.less
@@ -1028,7 +1028,7 @@ Note there are a different set of tooltip rules for the keyboard toggle
     --_horizontal-rule: var(--keyboard-horizontal-rule, 1px solid #303030);
 
     --_keycap-background: var(--keycap-background, #1f2022);
-    --_keycap-background-hover: var(--keycap-background, #2f3032);
+    --_keycap-background-hover: var(--keycap-background-hover, #2f3032);
     --_keycap-border: var(--_keycap-border, transparent);
     --_keycap-border-bottom: var(--_keycap-border-bottom, transparent);
     --_keycap-text: var(--keycap-text, #e3e4e8);
@@ -1069,7 +1069,7 @@ Note there are a different set of tooltip rules for the keyboard toggle
     --_horizontal-rule: var(--keyboard-horizontal-rule, 1px solid #303030);
 
     --_keycap-background: var(--keycap-background, #1f2022);
-    --_keycap-background-hover: var(--keycap-background, #2f3032);
+    --_keycap-background-hover: var(--keycap-background-hover, #2f3032);
     --_keycap-border: var(--_keycap-border, transparent);
     --_keycap-border-bottom: var(--_keycap-border-bottom, transparent);
     --_keycap-text: var(--keycap-text, #e3e4e8);
@@ -1109,7 +1109,7 @@ Note there are a different set of tooltip rules for the keyboard toggle
   --_horizontal-rule: var(--keyboard-horizontal-rule, 1px solid #fff);
 
   --_keycap-background: var(--keycap-background, white);
-  --_keycap-background-hover: var(--keycap-background, #f5f5f7);
+  --_keycap-background-hover: var(--keycap-background-hover, #f5f5f7);
   --_keycap-background-active: var(
     --keycap-background-active,
     var(--_accent-color)


### PR DESCRIPTION
I think it's a typo because the first occurrence is correct:

https://github.com/arnog/mathlive/blob/6175225fe2a26b7f1a4da5b1daec245045bf293d/css/virtual-keyboard.less#L62-L63

This simple fix will enable configuring the hover background color of keycaps.