### PR TITLE
fix: remove duplicate virtual keyboard selector in dark mode

### DIFF
--- a/css/virtual-keyboard.less
+++ b/css/virtual-keyboard.less
@@ -1057,43 +1057,41 @@ Note there are a different set of tooltip rules for the keyboard toggle
 
 /* Same as the media query, but with a class */
 [theme='dark'] .ML__keyboard {
-  .ML__keyboard {
-    --_accent-color: var(--keyboard-accent-color, #0b5c9c); // blue-300
-    --_background: var(--keyboard-background, #151515);
-    --_border: var(--keyboard-border, transparent);
-    --_toolbar-text: var(--keyboard-toolbar-text, #e3e4e8);
+  --_accent-color: var(--keyboard-accent-color, #0b5c9c); // blue-300
+  --_background: var(--keyboard-background, #151515);
+  --_border: var(--keyboard-border, transparent);
+  --_toolbar-text: var(--keyboard-toolbar-text, #e3e4e8);
 
-    --_toolbar-background-hover: var(
-      --keyboard-toolbar-background-hover,
-      #303030
-    );
-    --keyboard-toolbar-background-hover: #303030;
+  --_toolbar-background-hover: var(
+    --keyboard-toolbar-background-hover,
+    #303030
+  );
+  --keyboard-toolbar-background-hover: #303030;
 
-    --_horizontal-rule: var(--keyboard-horizontal-rule, 1px solid #303030);
+  --_horizontal-rule: var(--keyboard-horizontal-rule, 1px solid #303030);
 
-    --_keycap-background: var(--keycap-background, #1f2022);
-    --_keycap-background-hover: var(--keycap-background-hover, #2f3032);
-    --_keycap-border: var(--_keycap-border, transparent);
-    --_keycap-border-bottom: var(--_keycap-border-bottom, transparent);
-    --_keycap-text: var(--keycap-text, #e3e4e8);
+  --_keycap-background: var(--keycap-background, #1f2022);
+  --_keycap-background-hover: var(--keycap-background-hover, #2f3032);
+  --_keycap-border: var(--_keycap-border, transparent);
+  --_keycap-border-bottom: var(--_keycap-border-bottom, transparent);
+  --_keycap-text: var(--keycap-text, #e3e4e8);
 
-    --_keycap-secondary-background: var(--keycap-secondary-background, #3d4144);
-    --_keycap-secondary-background-hover: var(
-      --keycap-secondary-background-hover,
-      #4d5154
-    );
-    --_keycap-secondary-text: var(--keycap-secondary-text, #e7ebee);
-    --keycap-secondary-border: transparent;
-    --keycap-secondary-border-bottom: transparent;
-    --_keycap-secondary-border: var(--keycap-secondary-border, transparent);
-    --_keycap-secondary-border-bottom: var(
-      --keycap-secondary-border-bottom,
-      transparent
-    );
+  --_keycap-secondary-background: var(--keycap-secondary-background, #3d4144);
+  --_keycap-secondary-background-hover: var(
+    --keycap-secondary-background-hover,
+    #4d5154
+  );
+  --_keycap-secondary-text: var(--keycap-secondary-text, #e7ebee);
+  --keycap-secondary-border: transparent;
+  --keycap-secondary-border-bottom: transparent;
+  --_keycap-secondary-border: var(--keycap-secondary-border, transparent);
+  --_keycap-secondary-border-bottom: var(
+    --keycap-secondary-border-bottom,
+    transparent
+  );
 
-    --_variant-panel-background: var(--variant-panel-background, #303030);
-    --_variant-keycap-text-active: var(--variant-keycap-text-active, #fff);
-  }
+  --_variant-panel-background: var(--variant-panel-background, #303030);
+  --_variant-keycap-text-active: var(--variant-keycap-text-active, #fff);
 }
 
 [theme='light'] .ML__keyboard {


### PR DESCRIPTION
Fixed a typo that causes the keyboard to adapt to system theme even when `theme="dark"` is set.