### PR TITLE
fix: Stack overflow in sandboxed mode when in an iframe from different origin

### DIFF
--- a/src/virtual-keyboard/virtual-keyboard.ts
+++ b/src/virtual-keyboard/virtual-keyboard.ts
@@ -638,12 +638,8 @@ export class VirtualKeyboard implements VirtualKeyboardInterface, EventTarget {
 
       // Avoid an infinite messages loop if within one window
       const commandTarget = getCommandTarget(command!);
-      try {
-        if (window.top !== undefined) {
-          if (commandTarget !== 'virtual-keyboard' && window === window.parent)
-            return;
-        }
-      } catch (e) {}
+      if (window.top !== undefined && commandTarget !== 'virtual-keyboard')
+        return;
 
       this.executeCommand(command!);
       return;


### PR DESCRIPTION
handleMessage method in virtual-keyboard.ts ends up in infinite recursion. 
`"window === window.parent"` (current master) check prevents recursion for standard window but fails for iframe. 
`"window !== window.parent"` (previously) check prevents recursion in an iframe but fails for standard window.

if statement should only check `commandTarget !== 'virtual-keyboard'` and return if true. 
This way it prevents recursion for both, standard window and iframe.

I tested this on an extension for third party app.
Thanks for the great library!
