### PR TITLE
Only consider as touchCapable if primary pointer is touch

### DIFF
--- a/src/common/capabilities.ts
+++ b/src/common/capabilities.ts
@@ -6,7 +6,7 @@ export function isBrowser(): boolean {
 
 export function isTouchCapable(): boolean {
   if ('matchMedia' in window)
-    return window.matchMedia('(any-pointer: coarse)').matches;
+    return window.matchMedia('(pointer: coarse)').matches;
   return 'ontouchstart' in window || navigator.maxTouchPoints > 0;
 }
 


### PR DESCRIPTION
I think an improvement is that when `mathVirtualKeyboardPolicy` is 'auto', the virtual keyboard should only be shown (by default) if the user's device's _primary_ pointer is touch, not just if touchscreen is supported. 

My personal use case is as follows. I have a touchscreen laptop with two modes of input, keyboard and touchscreen. In normal use, I only use the regular keyboard, and the virtual keyboard is not useful. In this case, `window.matchMedia("(pointer: coarse)").matches == false`. Although I am _able_ to use the touchscreen when upright, in most cases I don't. Instead, when I wish to use the touchscreen, I physically fold the laptop. This causes an OS level change that disables the keyboard and also causes chrome to say `window.matchMedia("(pointer: coarse)").matches == true`. Thus, changing this one line conveniently addresses my use case.

I don't think this change would affect traditional desktops or plain touch devices; it only improves UX for devices with both touch and keyboard. This described behavior is consistent to the behavior of most other apps on my laptop: only when I enter "fold mode" does the OS virtual keyboard appear. 