### PR TITLE
Improved delete hotkeys

### DIFF
--- a/src/editor-model/commands-delete.ts
+++ b/src/editor-model/commands-delete.ts
@@ -1,7 +1,7 @@
 import { register } from '../editor/commands';
 import type { ModelPrivate } from './model-private';
 import { deleteForward, deleteBackward, deleteRange } from './delete';
-import { wordBoundaryOffset } from './commands';
+import { skip } from './commands';
 
 register(
   {
@@ -12,18 +12,10 @@ register(
     deleteBackward: (model: ModelPrivate): boolean => deleteBackward(model),
     deleteNextWord: (model: ModelPrivate): boolean =>
       model.contentWillChange({ inputType: 'deleteWordForward' }) &&
-      deleteRange(
-        model,
-        [model.anchor, wordBoundaryOffset(model, model.position, 'forward')],
-        'deleteWordForward'
-      ),
+      skip(model, 'forward', { delete: true }),
     deletePreviousWord: (model: ModelPrivate): boolean =>
       model.contentWillChange({ inputType: 'deleteWordBackward' }) &&
-      deleteRange(
-        model,
-        [model.anchor, wordBoundaryOffset(model, model.position, 'backward')],
-        'deleteWordBackward'
-      ),
+      skip(model, 'backward', { delete: true }),
     deleteToGroupStart: (model: ModelPrivate): boolean =>
       model.contentWillChange({ inputType: 'deleteSoftLineBackward' }) &&
       deleteRange(

--- a/src/editor/keybindings-definitions.ts
+++ b/src/editor/keybindings-definitions.ts
@@ -18,6 +18,9 @@ export const DEFAULT_KEYBINDINGS: Keybinding[] = [
   { key: 'alt+[Backspace]', command: 'deletePreviousWord' },
   { key: 'alt+[Delete]', command: 'deleteNextWord' },
 
+  { key: 'ctrl+[Backspace]', command: 'deleteToGroupStart' },
+  { key: 'ctrl+[Delete]', command: 'deleteToGroupEnd' },
+
   { key: 'alt+[ArrowLeft]', command: 'moveToPreviousWord' },
   { key: 'alt+[ArrowRight]', command: 'moveToNextWord' },
 
@@ -330,16 +333,6 @@ export const DEFAULT_KEYBINDINGS: Keybinding[] = [
     ifMode: 'math',
     command: 'addRowBefore',
   },
-  {
-    key: 'ctrl+[Backspace]',
-    ifMode: 'math',
-    command: 'removeRow',
-  },
-  {
-    key: 'cmd+[Backspace]',
-    ifMode: 'math',
-    command: 'removeRow',
-  },
 
   // {
   //   key: 'ctrl+[Comma]',
@@ -377,6 +370,11 @@ export const DEFAULT_KEYBINDINGS: Keybinding[] = [
     key: 'shift+[Backspace]',
     ifMode: 'math',
     command: 'removeColumn',
+  },
+  {
+    key: 'shift+[Delete]',
+    ifMode: 'math',
+    command: 'removeRow',
   },
 
   {

--- a/src/editor/keybindings-definitions.ts
+++ b/src/editor/keybindings-definitions.ts
@@ -13,10 +13,10 @@ export const DEFAULT_KEYBINDINGS: Keybinding[] = [
   { key: 'shift+[ArrowDown]', command: 'extendSelectionDownward' },
 
   { key: '[Backspace]', command: 'deleteBackward' },
-  { key: 'alt+[Delete]', command: 'deleteBackward' },
-
   { key: '[Delete]', command: 'deleteForward' },
-  { key: 'alt+[Backspace]', command: 'deleteForward' },
+
+  { key: 'alt+[Backspace]', command: 'deletePreviousWord' },
+  { key: 'alt+[Delete]', command: 'deleteNextWord' },
 
   { key: 'alt+[ArrowLeft]', command: 'moveToPreviousWord' },
   { key: 'alt+[ArrowRight]', command: 'moveToNextWord' },


### PR DESCRIPTION
I am an avid user of ctrl + backspace to delete whole words when typing, and I noticed there was ctrl + arrows for navigation already implemented, and none for deleting.

I ended up with including deletion functions for the existing keyboard navigation modifiers of `alt` and `ctrl`.

The reason for moving `removeRow` to `shift+[Delete]` is because this hotkey deletes a whole line in vscode (which seems like similar functionality), and it is close/similar to the `removeColumn` hotkey.

This seems to maintain expectations for keyboard functionality on Windows and Ubuntu (Australian keyboard), please let me know if this messes with other keyboard layouts / operating systems (I have no idea how you manage to maintain functionality for all of them, kudos to you).