### PR TITLE
feat: accept-all option for autocomplete

### DIFF
--- a/src/editor-mathfield/autocomplete.ts
+++ b/src/editor-mathfield/autocomplete.ts
@@ -121,24 +121,29 @@ export function acceptCommandSuggestion(model: ModelPrivate): boolean {
  */
 export function complete(
   mathfield: _Mathfield,
-  completion: 'reject' | 'accept' | 'accept-suggestion' = 'accept',
+  completion:
+    | 'reject'
+    | 'accept'
+    | 'accept-suggestion'
+    | 'accept-all' = 'accept',
   options?: { mode?: ParseMode; selectItem?: boolean }
 ): boolean {
   hideSuggestionPopover(mathfield);
   const latexGroup = getLatexGroup(mathfield.model);
   if (!latexGroup) return false;
 
-  if (completion === 'accept-suggestion') {
+  if (completion === 'accept-suggestion' || completion === 'accept-all') {
     const suggestions = getLatexGroupBody(mathfield.model).filter(
       (x) => x.isSuggestion
     );
-    if (suggestions.length === 0) return false;
-    for (const suggestion of suggestions) suggestion.isSuggestion = false;
+    if (suggestions.length !== 0) {
+      for (const suggestion of suggestions) suggestion.isSuggestion = false;
 
-    mathfield.model.position = mathfield.model.offsetOf(
-      suggestions[suggestions.length - 1]
-    );
-    return true;
+      mathfield.model.position = mathfield.model.offsetOf(
+        suggestions[suggestions.length - 1]
+      );
+    }
+    if (completion === 'accept-suggestion') return suggestions.length !== 0;
   }
 
   const body = getLatexGroupBody(mathfield.model).filter(


### PR DESCRIPTION
By default, when inputting LaTeX commands, accepting suggestion is done by `[Tab]` (`accept-suggestion`), and exiting to math mode is done by `[Enter]` (`accept`).

This PR adds a `accpet-all` option to autocomplete, which does both `accept-suggestion` and `accept`. If there are no suggestions, only `accept` is done. This allows users to bind keys to accept suggestion and exit latex mode at the same time, which is convenient. (which is also consistent with LyX if you know it)