### PR TITLE
Only pay attention to focusout of math-elements

### DIFF
--- a/src/virtual-keyboard/virtual-keyboard.ts
+++ b/src/virtual-keyboard/virtual-keyboard.ts
@@ -302,6 +302,7 @@ export class VirtualKeyboard implements VirtualKeyboardInterface, EventTarget {
     });
 
     document.addEventListener('focusout', (evt) => {
+      if ((evt.target as HTMLElement)?.tagName?.toLowerCase() !== 'math-field') return;
       const target = evt.target as MathfieldElement;
       if (target.mathVirtualKeyboardPolicy !== 'manual') {
         // If after a short delay the active element is no longer


### PR DESCRIPTION
In commit 645fa9d66b8a63 for #1914, the math virtual keyboard was prevented from disappearing when a math-field with mathVirtualKeyboardPolicy = "manual" loses focus.  However, if subsequently something else loses focus that isn't a math-field, the virtual keyboard disappears anyway.  The attached patch avoids that problem.

Thanks for this amazing library!
