### PR TITLE
Fix: 1. For \_ in \text command to produce expected output. 2. For Generting correct when \text used with superscript/subscript 

### DIFF
--- a/src/formats/atom-to-math-ml.ts
+++ b/src/formats/atom-to-math-ml.ts
@@ -238,6 +238,7 @@ function parseSubsup(base: string, stream: MathMLStream, options): boolean {
   if (!superscript && !subscript) return false;
 
   let mathML = '';
+
   if (superscript && subscript)
     mathML = `<msubsup>${base}${subscript}${superscript}</msubsup>`;
   else if (superscript) mathML = `<msup>${base}${superscript}</msup>`;
@@ -253,6 +254,10 @@ function scanText(stream: MathMLStream, final: number, options) {
   final = final ?? stream.atoms.length;
   const initial = stream.index;
   let mathML = '';
+
+  let superscript = indexOfSuperscriptInNumber(stream);
+  if (superscript >= 0 && superscript < final) final = superscript;
+
   while (stream.index < final && stream.atoms[stream.index].mode === 'text') {
     mathML += stream.atoms[stream.index].value
       ? stream.atoms[stream.index].value
@@ -261,11 +266,21 @@ function scanText(stream: MathMLStream, final: number, options) {
   }
 
   if (mathML.length > 0) {
-    stream.mathML += `<mtext ${makeID(
+    mathML = `<mtext ${makeID(
       stream.atoms[initial].id,
       options
     )}>${mathML}</mtext>`;
-    stream.lastType = 'mtext';
+
+    if (superscript < 0 && isSuperscriptAtom(stream)) {
+      superscript = stream.index;
+      stream.index += 1;
+    }
+
+    if (!parseSubsup(mathML, stream, options)) {
+      stream.mathML += mathML;
+      stream.lastType = 'mtext';
+    }
+
     return true;
   }
 

--- a/src/latex-commands/definitions-utils.ts
+++ b/src/latex-commands/definitions-utils.ts
@@ -409,6 +409,7 @@ const TEXT_SYMBOLS: Record<string, number> = {
   '\\$': 0x0024,
   '\\%': 0x0025,
   '\\&': 0x0026,
+  '\\_': 0x005f,
   '-': 0x002d, // In Math mode, '-' is substituted to U+2212, but we don't
   '\\textunderscore': 0x005f, // '_'
   '\\euro': 0x20ac,


### PR DESCRIPTION
1. Expected output for `\text{A\_2}` is `A_2`. Current mathlive version produces output `A\_2`.
    _ is a special character in TeX and for getting character '_' one should use `\_`
2. \text{A}_2 produces incorrect mathml. current mathml output is
```
<mrow><mtext >A</mtext><msub><mn>2</mn></msub></mrow>
``` 
Expected output is
```
<msub><mtext >A</mtext><mn>2</mn></msub>
```
This pull request adds `'\\_': 0x005f` to `TEXT_SYMBOLS` in  src/latex-commands/definitions-utils.ts to fix 1.
function `scanTeX` modified in src/formats/atom-to-math-ml.ts to take care of superscript and subscripts with `\text`   