### PR TITLE
Fix: When LaTeX array environment is used with @{} in column specifiers browser hangs.

### DIFF
--- a/src/core/v-box.ts
+++ b/src/core/v-box.ts
@@ -58,6 +58,9 @@ function getVListChildrenAndDepth(
   if ('individualShift' in params) {
     const oldChildren = params.individualShift;
     let prevChild = oldChildren[0];
+    if (prevChild == null)
+      return [null, 0];
+    
     const children: (VBoxChild | VBoxElementAndShift)[] = [prevChild];
 
     // Add in kerns to the list of params.children to get each element to be

--- a/src/formats/atom-to-math-ml.ts
+++ b/src/formats/atom-to-math-ml.ts
@@ -238,6 +238,7 @@ function parseSubsup(base: string, stream: MathMLStream, options): boolean {
   if (!superscript && !subscript) return false;
 
   let mathML = '';
+
   if (superscript && subscript)
     mathML = `<msubsup>${base}${subscript}${superscript}</msubsup>`;
   else if (superscript) mathML = `<msup>${base}${superscript}</msup>`;
@@ -253,6 +254,10 @@ function scanText(stream: MathMLStream, final: number, options) {
   final = final ?? stream.atoms.length;
   const initial = stream.index;
   let mathML = '';
+
+  let superscript = indexOfSuperscriptInNumber(stream);
+  if (superscript >= 0 && superscript < final) final = superscript;
+
   while (stream.index < final && stream.atoms[stream.index].mode === 'text') {
     mathML += stream.atoms[stream.index].value
       ? stream.atoms[stream.index].value
@@ -261,11 +266,21 @@ function scanText(stream: MathMLStream, final: number, options) {
   }
 
   if (mathML.length > 0) {
-    stream.mathML += `<mtext ${makeID(
+    mathML = `<mtext ${makeID(
       stream.atoms[initial].id,
       options
     )}>${mathML}</mtext>`;
-    stream.lastType = 'mtext';
+
+    if (superscript < 0 && isSuperscriptAtom(stream)) {
+      superscript = stream.index;
+      stream.index += 1;
+    }
+
+    if (!parseSubsup(mathML, stream, options)) {
+      stream.mathML += mathML;
+      stream.lastType = 'mtext';
+    }
+
     return true;
   }
 

--- a/src/formats/atom-to-math-ml.ts
+++ b/src/formats/atom-to-math-ml.ts
@@ -10,16 +10,16 @@ type MathMLStream = {
   lastType: string;
 };
 
-const APPLY_FUNCTION = '<mo>&#x2061;</mo>';
+const APPLY_FUNCTION = '<mo>\u2061</mo>';
 
-const INVISIBLE_TIMES = '<mo>&#8290;</mo>';
+const INVISIBLE_TIMES = '<mo>\u2062</mo>';
 
 function xmlEscape(string: string): string {
   return (
     string
       // .replace(/&/g, '&amp;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;')
+      .replace(/"/g, '\u0022')
+      .replace(/'/g, '\u0027')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
   );
@@ -84,16 +84,16 @@ function scanIdentifier(stream: MathMLStream, final: number, options) {
   }
 
   const SPECIAL_IDENTIFIERS = {
-    '\\exponentialE': '&#x02147;',
-    '\\imaginaryI': '&#x2148;',
-    '\\differentialD': '&#x2146;',
-    '\\capitalDifferentialD': '&#x2145;',
-    '\\alpha': '&#x03b1;',
-    '\\pi': '&#x03c0;',
-    '\\infty': '&#x221e;',
-    '\\forall': '&#x2200;',
-    '\\nexists': '&#x2204;',
-    '\\exists': '&#x2203;',
+    '\\exponentialE': '\u2147',
+    '\\imaginaryI': '\u2148',
+    '\\differentialD': '\u2146',
+    '\\capitalDifferentialD': '\u2145',
+    '\\alpha': '\u03b1',
+    '\\pi': '\u03c0',
+    '\\infty': '\u221e',
+    '\\forall': '\u2200',
+    '\\nexists': '\u2204',
+    '\\exists': '\u2203',
     '\\hbar': '\u210F',
     '\\cdotp': '\u22C5',
     '\\ldots': '\u2026',
@@ -389,10 +389,10 @@ function scanOperator(stream: MathMLStream, final: number, options) {
   if (!atom) return false;
 
   const SPECIAL_OPERATORS = {
-    '\\ne': '&ne;',
-    '\\neq': '&neq;',
-    '\\pm': '&#177;',
-    '\\times': '&#215;',
+    '\\ne': '\u2260',
+    '\\neq': '\u2260',
+    '\\pm': '\u00B1',
+    '\\times': '\u00D7',
     '\\colon': ':',
     '\\vert': '|',
     '\\Vert': '\u2225',
@@ -551,7 +551,7 @@ export function toMathML(
         ) {
           // If this is a fraction preceded by a number (e.g. 2 1/2),
           // add an "invisible plus" (U+0264) character in front of it
-          mathML = '<mo>&#x2064;</mo>' + mathML;
+          mathML = '<mo>\u2064</mo>' + mathML;
         }
 
         if (result.atoms[result.index].type === 'genfrac')
@@ -706,16 +706,16 @@ function atomToMathML(atom, options): string {
   };
 
   const SPECIAL_ACCENTS = {
-    '\\vec': '&#x20d7;',
-    '\\acute': '&#x00b4;',
-    '\\grave': '&#x0060;',
-    '\\dot': '&#x02d9;',
-    '\\ddot': '&#x00a8;',
-    '\\tilde': '&#x007e;',
-    '\\bar': '&#x00af;',
-    '\\breve': '&#x02d8;',
-    '\\check': '&#x02c7;',
-    '\\hat': '&#x005e;',
+    '\\vec': '\u20d7',
+    '\\acute': '\u00b4',
+    '\\grave': '\u0060',
+    '\\dot': '\u02d9',
+    '\\ddot': '\u00a8',
+    '\\tilde': '\u007e',
+    '\\bar': '\u00af',
+    '\\breve': '\u02d8',
+    '\\check': '\u02c7',
+    '\\hat': '\u005e',
   };
   switch (atom.type) {
     case 'first':
@@ -796,8 +796,8 @@ function atomToMathML(atom, options): string {
 
       if (atom.hasBarLine) {
         result += '<mfrac>';
-        result += toMathML(atom.above, options) || '<mi>&nbsp;</mi>';
-        result += toMathML(atom.below, options) || '<mi>&nbsp;</mi>';
+        result += toMathML(atom.above, options) || '<mi>\u00A0</mi>';
+        result += toMathML(atom.below, options) || '<mi>\u00A0</mi>';
         result += '</mfrac>';
       } else {
         // No bar line, i.e. \choose, etc...
@@ -933,13 +933,13 @@ function atomToMathML(atom, options): string {
       if (command === '\\char') {
         // It's a \char command
         result =
-          '&#x' + ('000000' + atom.args[0].number.toString(16)).slice(-4) + ';';
+          '\\u' + ('000000' + atom.args[0].number.toString(16)).slice(-4) + ';';
       } else if (result.length > 0 && result.startsWith('\\')) {
         // This is an identifier with no special handling. Use the
         // Unicode value
         if (typeof atom.value === 'string' && atom.value.charCodeAt(0) > 255) {
           result =
-            '&#x' +
+            '\\u' +
             ('000000' + atom.value.charCodeAt(0).toString(16)).slice(-4) +
             ';';
         } else if (typeof atom.value === 'string')
@@ -1040,7 +1040,7 @@ function atomToMathML(atom, options): string {
       break;
 
     case 'space':
-      result += '&nbsp;';
+      result += '\u00A0';
       break;
 
     case 'subsup':


### PR DESCRIPTION
When array environment with `@{}` in column specifier as below the browser sometimes hangs and content always disappear or does not update in WYSIWYG editor

```
\left\{
\begin{array}{@{}l@{}}
A + B\\
C + D
\end{array}
\right\}
```  

`@{}` is commonly used in array to remove space before/after a column. If above LaTeX code is used in the mathlive demo page

Following error appears in console

```
Uncaught TypeError: Cannot read properties of undefined (reading 'shift')
    at Qp (mathlive.min.mjs:192:15305)
    at eh (mathlive.min.mjs:192:15993)
    at new U (mathlive.min.mjs:192:17147)
    at Dh (mathlive.min.mjs:2803:18674)
    at t.render (mathlive.min.mjs:2803:14292)
    at nh (mathlive.min.mjs:192:42110)
    at t.createBox (mathlive.min.mjs:192:29931)
    at t.render (mathlive.min.mjs:2803:23269)
    at nh (mathlive.min.mjs:192:42110)
    at t.createBox (mathlive.min.mjs:192:29931)
```

A check added in `getVListChildrenAndDepth` function to check if prevChild is null. If so `[null, 0]` is returned to prevent this issue.
