### PR TITLE
fix: keep context menu above other mathfield components

### DIFF
--- a/css/mathfield.less
+++ b/css/mathfield.less
@@ -30,10 +30,6 @@
   align-items: flex-end;
   min-height: 39px; /* Need some room for the virtual keyboard toggle */
   width: 100%;
-  
-  /* Encourage browsers to consider allocating a hardware accelerated
-   layer for this element. */
-  isolation: isolate;
 
   /* Prevent the browser from trying to interpret touch gestures in the field */
   /* "Disabling double-tap to zoom removes the need for browsers to


### PR DESCRIPTION
Removing the `isolation: isolate` css property allows the context menu to layer above other mathfield components that appear later in the DOM. This change prevents multiple mathfields from having a context menu open at the same time. The isolation setting was preventing the click handler div below the context menu from handling clicks over other mathfield components (or over other clickable elements) that appeared later than the mathfield in the DOM. Because of this, clicking on other mathfields or buttons did not close the context menu and two cursors would also appear leading to confusing behavior. This was also leading to rendering issues on Firefox which can be seen in the first screen recording below. The rendering issues only appeared on Firefox. However, the multiple context menus issue occurs on both Firefox and Chrome.

Behavior before change:
[before.webm](https://github.com/arnog/mathlive/assets/6439649/d1482271-b664-40ef-984e-114ebdc7b786)

Behavior after change:
[after.webm](https://github.com/arnog/mathlive/assets/6439649/bf6930e4-363f-462c-b420-b1db290aac55)
