### PR TITLE
tests: add regression test that covers #2291, #2293, #2294

### DIFF
--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -424,3 +424,21 @@ test('cross-origin iframe with physical keyboard', async ({
     expect(latex).toBe(String.raw`\frac{x}{20+z}`);
   }
 });
+
+test('keyboard shortcuts with placeholders (#2291, #2293, #2294)', async ({
+  page,
+}) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  // use latex mode for math field with default settings
+  await page.locator('#mf-1').pressSequentially('/f*g');
+  await page.locator('#mf-1').press('ArrowRight');
+  await page.locator('#mf-1').press('a');
+  await page.locator('#mf-1').press('ArrowRight');
+  await page.locator('#mf-1').pressSequentially('*x');
+
+  // check latex of result
+  expect(
+    await page.locator('#mf-1').evaluate((e: MathfieldElement) => e.value)
+  ).toBe(String.raw`\frac{f\cdot g}{a}\cdot x`);
+});


### PR DESCRIPTION
Many thanks for the fixes for #2291, #2293, and #2294. The tests for my app are now passing. I'm looking forward to rolling out the new context menu feature!

This pull request adds a Playwright regression test that covers #2291, #2293, and #2294.