### PR TITLE
fix: fixes regression of firefox border selection bug

### DIFF
--- a/css/mathfield.less
+++ b/css/mathfield.less
@@ -42,6 +42,8 @@
   min-height: 39px; /* Need some room for the virtual keyboard toggle */
   width: 100%;
 
+  pointer-events: auto;
+
   /* Prevent the browser from trying to interpret touch gestures in the field */
   /* "Disabling double-tap to zoom removes the need for browsers to
         delay the generation of click events when the user taps the screen." */
@@ -290,6 +292,10 @@ with this style */
 
 :host(:focus) .ML__selection {
   background: var(--_selection-background-color) !important;
+}
+
+:host {
+  pointer-events: none;
 }
 
 .ML__contains-caret.ML__close,


### PR DESCRIPTION
Appears to be a regression of #1861, restores the original fix from [5b3999b](https://github.com/arnog/mathlive/commit/5b3999bca74eb2ac55edeaa977a7edd1ecb8b48e). The main side effect of this fix is that mathfield elements cannot be selected by clicking directly on the border but it fixes the bug in Firefox where clicking multiple times on the border leads to a focused mathfield that cannot be edited until focus is lost and regained (also fixes the multiple cursor issue on firefox that can occur with the same sequence of events).

Another benefit of this fix is that the default browser context menu for a text area, instead of the expected MathLive custom context menu, no longer appears when right clicking on the border of the mathfield (observed on Firefox and Chrome, not tested on Safari).