### PR TITLE
fix: prevent context menu highlight from persisting for touch input

### DIFF
--- a/src/ui/menu/menu-item.ts
+++ b/src/ui/menu/menu-item.ts
@@ -403,6 +403,7 @@ export class _MenuItemState<T> implements MenuItemState<T> {
     setTimeout(() => {
       this.active = true;
       setTimeout(() => {
+        this.active = false;
         this.rootMenu.hide();
         this.dispatchSelect();
       }, BLINK_SPEED);


### PR DESCRIPTION
When using touch input with the context menu, all of the previously clicked context menu items remain highlighted when the context menu is reopened (see first screen recording below, tested on Chrome and Edge). This change ensures that the most recently clicked item will be returned to the non-active state after the event fires. I think the root cause of the issue is that the `pointerenter` and `pointerleave`  don't both fire for touch input so the accounting of `activeMenuItem` is not working the same way as it does for mouse events. I tried setting `touch-action: none` on the menu items as a alternative solution, but that did not work.

Screen Recording of Previous Behavior:
[before_context_menu_fix.webm](https://github.com/arnog/mathlive/assets/6439649/e4471c16-7d7f-43a8-a9b7-f9cc35e3caf5)


Screen Recording of Behavior After Proposed Change:
[after_context_menu_fix.webm](https://github.com/arnog/mathlive/assets/6439649/167eb8bc-bc8f-4795-b62f-8c748fa96b26)



