### PR TITLE
fix: test for the existence of TouchEvent before using

### DIFF
--- a/src/ui/events/utils.ts
+++ b/src/ui/events/utils.ts
@@ -6,7 +6,7 @@ export function eventLocation(
   if (evt instanceof MouseEvent || evt instanceof PointerEvent)
     return { x: evt.clientX, y: evt.clientY };
 
-  if (evt instanceof TouchEvent) {
+  if (typeof TouchEvent !== 'undefined' && evt instanceof TouchEvent) {
     const result = [...evt.touches].reduce(
       (acc, x) => ({ x: acc.x + x.clientX, y: acc.y + x.clientY }),
       { x: 0, y: 0 }
@@ -36,7 +36,7 @@ export function keyboardModifiersFromEvent(ev: Event): KeyboardModifiers {
   if (
     ev instanceof MouseEvent ||
     ev instanceof PointerEvent ||
-    ev instanceof TouchEvent ||
+    (typeof TouchEvent !== 'undefined' && ev instanceof TouchEvent) ||
     ev instanceof KeyboardEvent
   ) {
     if (ev.altKey) result.alt = true;


### PR DESCRIPTION
The desktop versions of Safari and Firefox do not define the `TouchEvent` constructor (see the [TouchEvent MDN page](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent#browser_compatibility) for details). Currently, two of the functions in `utils.ts` use `TouchEvent`, which leads to an unhandled `ReferenceError: Can't find variable: TouchEvent` in certain situations. In particular, I was noticing this issue when using arrows to navigate MathLive's context menu on desktop Safari leading to the arrow keys not doing anything with the context menu. This fix checks for the existence of `TouchEvent` before using it and fixes the arrow key navigation of MathLive's context menu on desktop Safari and Firefox.  