### PR TITLE
fix: persist focus when switching tabs

### DIFF
--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -1724,11 +1724,7 @@ If you are using Vue, this may be because you are using the runtime-only build o
       { once: true, signal }
     );
 
-    // If we haven't received a visibility change after a short delay,
-    // stop waiting for it (the delay has to be longer than at least
-    // 16ms: the documents that are not visible are throttled by the
-    // browser)
-    setTimeout(() => controller.abort(), 100);
+    document.addEventListener('focusin', () => controller.abort(), { once: true });
   }
 
   onInput(text: string): void {


### PR DESCRIPTION
For the callbacks related to persisting focus when switching tabs, this pull request changes from a timeout based approach to cancel the callbacks to a method that looks for change in focus. The timeout based method was not working on Chrome and Firefox in Windows. The new approach still ensures that only the most recent math-field element will have a `visibilitychange` callback associated with it.