### PR TITLE
fix: Safari context menu cut fix

### DIFF
--- a/src/editor-mathfield/commands.ts
+++ b/src/editor-mathfield/commands.ts
@@ -112,11 +112,12 @@ registerCommand(
       if (mathfield.model.selectionIsCollapsed) mathfield.select();
 
       if (
-        'queryCommandSupported' in document &&
-        document.queryCommandSupported('copy')
-      )
-        document.execCommand('copy');
-      else {
+        !(
+          'queryCommandSupported' in document &&
+          document.queryCommandSupported('copy') &&
+          document.execCommand('copy')
+        )
+      ) {
         mathfield.element!.querySelector('.ML__keyboard-sink')!.dispatchEvent(
           new ClipboardEvent('copy', {
             bubbles: true,

--- a/src/editor-mathfield/commands.ts
+++ b/src/editor-mathfield/commands.ts
@@ -136,11 +136,12 @@ registerCommand(
       mathfield.focus();
 
       if (
-        'queryCommandSupported' in document &&
-        document.queryCommandSupported('cut')
-      )
-        document.execCommand('cut');
-      else {
+        !(
+          'queryCommandSupported' in document &&
+          document.queryCommandSupported('cut') &&
+          document.execCommand('cut')
+        )
+      ) {
         mathfield.element!.querySelector('.ML__keyboard-sink')!.dispatchEvent(
           new ClipboardEvent('cut', {
             bubbles: true,

--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -1777,7 +1777,8 @@ If you are using Vue, this may be because you are using the runtime-only build o
       this.stopCoalescingUndo();
 
       // Copy to the clipboard
-      ModeEditor.onCopy(this, ev);
+      if (ev.clipboardData) ModeEditor.onCopy(this, ev);
+      else ModeEditor.copyToClipboard(this, 'latex');
 
       // Delete the selection
       deleteRange(this.model, range(this.model.selection), 'deleteByCut');

--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -1790,7 +1790,8 @@ If you are using Vue, this may be because you are using the runtime-only build o
   }
 
   onCopy(ev: ClipboardEvent): void {
-    ModeEditor.onCopy(this, ev);
+    if (ev.clipboardData) ModeEditor.onCopy(this, ev);
+    else ModeEditor.copyToClipboard(this, 'latex');
   }
 
   onPaste(ev: ClipboardEvent): boolean {

--- a/src/public/mathfield-element.ts
+++ b/src/public/mathfield-element.ts
@@ -417,7 +417,7 @@ const DEPRECATED_OPTIONS = {
  * To style the virtual keyboard toggle, use the `virtual-keyboard-toggle` CSS
  * part. To use it, define a CSS rule with a `::part()` selector
  * for example:
- * 
+ *
  * ```css
  * math-field::part(virtual-keyboard-toggle) {
  *  color: red;

--- a/test/playwright-tests/mouse.spec.ts
+++ b/test/playwright-tests/mouse.spec.ts
@@ -36,7 +36,12 @@ test('double/triple click to select', async ({ page }) => {
   );
 });
 
-test('context menu select all and cut', async ({ page }) => {
+test('context menu select all and cut', async ({ page, browserName }) => {
+  test.skip(
+    browserName === 'webkit' && Boolean(process.env.CI),
+    'Keyboard paste does not work when headless on Linux (works when run with gui on Linux or headless/gui on MacOs)'
+  );
+
   const modifierKey = /Mac|iPod|iPhone|iPad/.test(
     await page.evaluate(() => navigator.platform)
   )
@@ -71,7 +76,7 @@ test('context menu select all and cut', async ({ page }) => {
 
   // initial contents should now be there
   expect(
-    await page.locator('#mf-1').evaluate((mfe: MathfieldElement) => mfe.value)
+    await page.locator('#mf-1').evaluate((mfe: MathfieldElement) => mfe.value.trim())
   ).toBe('x+y=30');  
 });
 

--- a/test/playwright-tests/mouse.spec.ts
+++ b/test/playwright-tests/mouse.spec.ts
@@ -35,3 +35,43 @@ test('double/triple click to select', async ({ page }) => {
     String.raw`\left(x+y\right)-\left(125+s\right)=34`
   );
 });
+
+test('context menu select all and cut', async ({ page }) => {
+  const modifierKey = /Mac|iPod|iPhone|iPad/.test(
+    await page.evaluate(() => navigator.platform)
+  )
+    ? 'Meta'
+    : 'Control';
+
+  await page.goto('/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').pressSequentially('x+y=30');
+
+  // check initial contents
+  expect(
+    await page.locator('#mf-1').evaluate((mfe: MathfieldElement) => mfe.value)
+  ).toBe('x+y=30');  
+
+  // use select all and cut from the context menu
+  await page.locator('#mf-1').click({button: "right"});
+  await page.locator('text=Select All').click();
+  await new Promise((resolver) => setTimeout(resolver, 1000));
+  await page.locator('#mf-1').click({button: "right"});
+  await page.locator('text=Cut').click();
+  await new Promise((resolver) => setTimeout(resolver, 1000));
+
+  // make sure field is empty after
+  expect(
+    await page.locator('#mf-1').evaluate((mfe: MathfieldElement) => mfe.value)
+  ).toBe('');
+  
+  // paste original contents back
+  // need to use keyboard shortcut since context menu paste requires browser permission
+  await page.locator('#mf-1').press(`${modifierKey}+v`);
+
+  // initial contents should now be there
+  expect(
+    await page.locator('#mf-1').evaluate((mfe: MathfieldElement) => mfe.value)
+  ).toBe('x+y=30');  
+});
+

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -444,6 +444,11 @@ test('keyboard shortcuts with placeholders (#2291, #2293, #2294)', async ({
 });
 
 test('keyboard cut and paste', async ({ page, browserName }) => {
+  test.skip(
+    browserName === 'webkit' && Boolean(process.env.CI),
+    'Keyboard paste does not work when headless on Linux (works when run with gui on Linux or headless/gui on MacOs)'
+  );
+
   const modifierKey = /Mac|iPod|iPhone|iPad/.test(
     await page.evaluate(() => navigator.platform)
   )
@@ -480,6 +485,6 @@ test('keyboard cut and paste', async ({ page, browserName }) => {
 
   // initial contents should now be there
   expect(
-    await page.locator('#mf-1').evaluate((mfe: MathfieldElement) => mfe.value)
+    await page.locator('#mf-1').evaluate((mfe: MathfieldElement) => mfe.value.trim())
   ).toBe('30=r+t');  
 });


### PR DESCRIPTION
Fixes context menu Cut functionality for Safari (previously the Cut option from the context menu would do nothing on Safari). Tests have also been added for both keyboard cut/paste shortcuts and also for context menu cut/paste.

The fix checks the return value for `execCommand`, which will be `false` if it fails or is not allowed. In this case, it falls back to manually triggering the cut event.