### PR TITLE
fix: fixed invalid Chinese locale configuration of MathfieldElement

### DIFF
--- a/src/editor/l10n-strings.ts
+++ b/src/editor/l10n-strings.ts
@@ -969,7 +969,7 @@ export const STRINGS = {
   },
 
   // Simplified Chinese
-  zh_cn: {
+  ['zh-cn']: {
     'keyboard.tooltip.symbols': '符号',
     'keyboard.tooltip.greek': '希腊字母',
     'keyboard.tooltip.numeric': '数字',
@@ -1043,7 +1043,7 @@ export const STRINGS = {
   },
 
   // Traditional Chinese
-  zh_tw: {
+  ['zh-tw']: {
     'keyboard.tooltip.symbols': '符號',
     'keyboard.tooltip.greek': '希臘字母',
     'keyboard.tooltip.numeric': '數字',


### PR DESCRIPTION
Fixed issue #2373

- `MathfieldElement.locale = 'zh-cn'`

![7_K}}3IRGN2DYOVP)S7 4KR](https://github.com/arnog/mathlive/assets/34965556/356272ff-d137-4137-a279-cfa0da1aea2a)

- `MathfieldElement.locale = 'zh-tw'`

![0_%}Q%}GB%1B4@)7$O~%{I6](https://github.com/arnog/mathlive/assets/34965556/ae7965b6-1f33-4561-a2fa-3641ad5fec35)



