### PR TITLE
fix pointer events scroll and cursor position

### DIFF
--- a/css/mathfield.less
+++ b/css/mathfield.less
@@ -41,6 +41,8 @@
   align-items: flex-end;
   min-height: 39px; /* Need some room for the virtual keyboard toggle */
   width: 100%;
+  padding: 4px;
+  box-sizing: border-box;
 
   /* This attribute is necessary to work around a Firefox issue where 
   where clicking multiple times on the border leads to a focused mathfield that cannot be edited until focus is lost and regained (also fixes the multiple cursor issue on firefox that can occur with the same sequence of events).
@@ -106,6 +108,14 @@
     0 1px 5px 0 rgba(0, 0, 0, 0.12), 
     0 3px 1px -2px rgba(0, 0, 0, 0.2)
   );
+}
+
+// prevent pointer-down event on touch devices if the host isn't focused
+// this allows scrolling if you touch unfocused fields
+@media (hover: none) and (pointer: coarse) {
+  :host(:not(:focus)) .ML__container {
+    pointer-events: none;
+  }
 }
 
 // @media (prefers-color-scheme: dark) {
@@ -307,10 +317,6 @@ with this style */
 
 :host(:focus) .ML__selection {
   background: var(--_selection-background-color) !important;
-}
-
-:host {
-  pointer-events: none;
 }
 
 .ML__contains-caret.ML__close,

--- a/src/common/stylesheet.ts
+++ b/src/common/stylesheet.ts
@@ -42,7 +42,7 @@ export function getStylesheetContent(id: StylesheetId): string {
     //
     case 'mathfield-element':
       content = `
-    :host { display: inline-block; background-color: field; color: fieldtext; border-width: 1px; border-style: solid; border-color: #acacac; border-radius: 2px; padding:4px;}
+    :host { display: inline-block; background-color: field; color: fieldtext; border-width: 1px; border-style: solid; border-color: #acacac; border-radius: 2px;}
     :host([hidden]) { display: none; }
     :host([disabled]), :host([disabled]:focus), :host([disabled]:focus-within) { outline: none; opacity:  .5; }
     :host(:focus), :host(:focus-within) {
@@ -52,9 +52,6 @@ export function getStylesheetContent(id: StylesheetId): string {
     :host([readonly]:focus), :host([readonly]:focus-within),
     :host([read-only]:focus), :host([read-only]:focus-within) {
       outline: none;
-    }
-    @media (hover: none) and (pointer: coarse) {
-      :host(:not(:focus)) :first-child { pointer-events: none !important; }
     }`;
       break;
     case 'core':

--- a/src/public/mathfield-element.ts
+++ b/src/public/mathfield-element.ts
@@ -1339,6 +1339,9 @@ export class MathfieldElement extends HTMLElement implements Mathfield {
           // Check if a \href command was clicked on (or its children)
           const offset = this.getOffsetFromPoint(evt.clientX, evt.clientY);
           if (offset >= 0) MathfieldElement.openUrl(getHref(mf, offset));
+          // set cursor position if selection is collapsed on touch events
+          if (evt.pointerType === 'touch' && this.selectionIsCollapsed)
+            this.position = offset;
         }
       },
       { once: true }


### PR DESCRIPTION
This PR fixes scrolling and cursor position regressions.
- Disable pointer events on `.ML__container` for touch pointers.
- Set cursor position on `pointerup` for touch pointers.
- Move the padding from the host to `.ML__container` to avoid focusing the math field without triggering `pointerdown`.