### PR TITLE
fix: improved refocus behavior on window exit and then return

### DIFF
--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -1716,26 +1716,20 @@ If you are using Vue, this may be because you are using the runtime-only build o
       // don't do that for custom elements, so we do it ourselves. @futureweb
       //
 
-      // Wait for the window/document visibility to change
+      // Wait for the window focus to change
       // (the mathfield gets blurred before the window)
       const controller = new AbortController();
       const signal = controller.signal;
-      document.addEventListener(
-        'visibilitychange',
+      window.addEventListener(
+        'blur',
         () => {
-          if (document.visibilityState === 'hidden') {
-            document.addEventListener(
-              'visibilitychange',
-              () => {
-                if (
-                  isValidMathfield(this) &&
-                  document.visibilityState === 'visible'
-                )
-                  this.focus({ preventScroll: true });
-              },
-              { once: true, signal }
-            );
-          }
+          window.addEventListener(
+            'focus',
+            () => {
+              if (isValidMathfield(this)) this.focus({ preventScroll: true });
+            },
+            { once: true, signal }
+          );
         },
         { once: true, signal }
       );
@@ -1743,6 +1737,12 @@ If you are using Vue, this may be because you are using the runtime-only build o
       // If something else gets the focus (could be the mathfield too),
       // cancel the above
       document.addEventListener('focusin', () => controller.abort(), {
+        once: true,
+      });
+
+      // If user clicks anywhere, cancel the refocus (covers case where
+      // click doesn't cause an element to come into focus)
+      document.addEventListener('click', () => controller.abort(), {
         once: true,
       });
     }


### PR DESCRIPTION
This pull request fixes two issues with focus handling when switching away from and back to a tab with a `mathfield` element to make the behavior the same as a standard HTML `input` or `textarea` element. The current behavior is correct when switching tabs (the first test in the two videos below) but doesn't correctly handle the case when switching non-overlapping windows (second test in the two videos below). This was corrected by looking for the window `blur` event rather than the `visibilitychange` event since `visibilitychange` is not triggered when switching windows that are not overlapping.

The second issue that is addressed is correctly handling the case where the user clicks off of the `mathfield` element but doesn't select another element (third test in the videos below, users commonly do this to unselect a `mathfield`). Previously, the mathfield would incorrectly regain focus when the tab is refocused even though the mathfield wasn't previously focused. This behavior is confusing to users and may cause unintentional scrolling if the user has scrolled the mathfield out of view (this may be related to the issues raised in #2337). By using the `click` event of document to cancel the refocus, this issue is corrected and now matches the normal HTML `input` element behavior.

This fix has been tested on Edge, Firefox, and Safari.

Previous focus behavior:
![Previous focus behavior screen capture video](https://github.com/user-attachments/assets/f215b5f4-d702-4305-b81f-904871ee692b)

New focus behavior:
![New focus behavior screen capture video](https://github.com/user-attachments/assets/661561a0-893c-4529-8106-5dc5fd503999)


