### PR TITLE
feat: Added option for sticky display of variants panel with a single click

### DIFF
--- a/examples/popover-variants-panel/index.html
+++ b/examples/popover-variants-panel/index.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8" />
+    <title>MathLive Basic Example</title>
+    <style>
+      body {
+        color: #444;
+        background-color: #f9f9f9;
+      }
+
+      main {
+        max-width: 820px;
+        margin: auto;
+      }
+
+      math-field {
+        width: 100%;
+        border: 1px solid #ddd;
+        padding: 5px;
+        margin: 10px 0 10px 0;
+        border-radius: 5px;
+        background-color: #fff;
+      }
+
+      #value,
+      #result {
+        padding: 5px;
+        border-radius: 5px;
+        border: 1px solid #000;
+
+        color: rgb(241, 188, 91);
+        background: #35434e;
+
+        font-family: monospace;
+        margin-bottom: 1em;
+      }
+    </style>
+  </head>
+
+  <body>
+    <main>
+      <h2>MathLive Popover Variants Panel Example</h2>
+      <math-field id="mf" virtual-keyboard-mode="manual"></math-field>
+      <div id="value"></div>
+    </main>
+
+    <script type="module">
+      import "/dist/mathlive.mjs";
+
+      mathVirtualKeyboard.layouts = [
+        {
+          label: "Basic",
+          rows: [
+            [
+              "[7]",
+              "[8]",
+              "[9]",
+              "[+]",
+              "[separator-5]",
+              { latex: "abc", variants: ["a", "b", "c"], popover: true },
+              { latex: "xyz", variants: ["x", "y", "z"], popover: true },
+            ],
+            [
+              "[4]",
+              "[5]",
+              "[6]",
+              "[-]",
+              "[separator-5]",
+              { latex: "cm", variants: ["cm", "m", "km"], popover: true },
+              {
+                latex: "cm^2",
+                variants: ["cm^2", "m^2", "km^2"],
+                popover: true,
+              },
+            ],
+            [
+              "[1]",
+              "[2]",
+              "[3]",
+              "\\times",
+              "[separator-5]",
+              { label: "[backspace]", width: 2 },
+            ],
+            [
+              "[.]",
+              "[0]",
+              "[=]",
+              "\\div",
+              "[separator-5]",
+              { label: "[return]", width: 2 },
+            ],
+          ],
+        },
+      ];
+
+      document.getElementById("mf").addEventListener("input", (ev) => {
+        const mf = ev.target;
+        document.getElementById("value").innerHTML = mf.getValue();
+      });
+    </script>
+  </body>
+</html>

--- a/examples/sticky-variant-panel/index.html
+++ b/examples/sticky-variant-panel/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
   <head>
     <meta charset="utf-8" />
-    <title>MathLive Basic Example</title>
+    <title>MathLive Sticky Variants Panel Example</title>
     <style>
       body {
         color: #444;

--- a/examples/sticky-variant-panel/index.html
+++ b/examples/sticky-variant-panel/index.html
@@ -58,8 +58,16 @@
               "[9]",
               "[+]",
               "[separator-5]",
-              { latex: "abc", variants: ["a", "b", "c"], popover: true },
-              { latex: "xyz", variants: ["x", "y", "z"], popover: true },
+              {
+                latex: "abc",
+                variants: ["a", "b", "c"],
+                stickyVariantPanel: true,
+              },
+              {
+                latex: "xyz",
+                variants: ["x", "y", "z"],
+                stickyVariantPanel: true,
+              },
             ],
             [
               "[4]",
@@ -67,11 +75,15 @@
               "[6]",
               "[-]",
               "[separator-5]",
-              { latex: "cm", variants: ["cm", "m", "km"], popover: true },
+              {
+                latex: "cm",
+                variants: ["cm", "m", "km"],
+                stickyVariantPanel: true,
+              },
               {
                 latex: "cm^2",
                 variants: ["cm^2", "m^2", "km^2"],
-                popover: true,
+                stickyVariantPanel: true,
               },
             ],
             [

--- a/examples/sticky-variant-panel/index.html
+++ b/examples/sticky-variant-panel/index.html
@@ -40,7 +40,7 @@
 
   <body>
     <main>
-      <h2>MathLive Popover Variants Panel Example</h2>
+      <h2>MathLive Sticky Variants Panel Example</h2>
       <math-field id="mf" virtual-keyboard-mode="manual"></math-field>
       <div id="value"></div>
     </main>

--- a/src/api.md
+++ b/src/api.md
@@ -4728,6 +4728,20 @@ Name of the layer to shift to when the key is pressed
 
 </MemberCard>
 
+<a id="popover" name="popover"></a>
+
+<MemberCard>
+
+##### VirtualKeyboardKeycap.popover
+
+```ts
+popover: boolean;
+```
+
+Open variants panel without long press and does not close automatically
+
+</MemberCard>
+
 <a id="shift" name="shift"></a>
 
 <MemberCard>

--- a/src/api.md
+++ b/src/api.md
@@ -4728,20 +4728,6 @@ Name of the layer to shift to when the key is pressed
 
 </MemberCard>
 
-<a id="popover" name="popover"></a>
-
-<MemberCard>
-
-##### VirtualKeyboardKeycap.popover
-
-```ts
-popover: boolean;
-```
-
-Open variants panel without long press and does not close automatically
-
-</MemberCard>
-
 <a id="shift" name="shift"></a>
 
 <MemberCard>
@@ -4753,6 +4739,20 @@ shift: string | Partial<VirtualKeyboardKeycap>;
 ```
 
 Variant of the keycap when the shift key is pressed
+
+</MemberCard>
+
+<a id="stickyvariantpanel" name="stickyvariantpanel"></a>
+
+<MemberCard>
+
+##### VirtualKeyboardKeycap.stickyVariantPanel
+
+```ts
+stickyVariantPanel: boolean;
+```
+
+Open variants panel without long press and does not close automatically
 
 </MemberCard>
 

--- a/src/public/virtual-keyboard.ts
+++ b/src/public/virtual-keyboard.ts
@@ -98,6 +98,9 @@ export interface VirtualKeyboardKeycap {
 
   /** Name of the layer to shift to when the key is pressed */
   layer: string;
+
+  /** Open variants panel without long press and does not close automatically */
+  popover: boolean;
 }
 /**
  * @category Virtual Keyboard

--- a/src/public/virtual-keyboard.ts
+++ b/src/public/virtual-keyboard.ts
@@ -100,7 +100,7 @@ export interface VirtualKeyboardKeycap {
   layer: string;
 
   /** Open variants panel without long press and does not close automatically */
-  popover: boolean;
+  stickyVariantPanel: boolean;
 }
 /**
  * @category Virtual Keyboard

--- a/src/virtual-keyboard/utils.ts
+++ b/src/virtual-keyboard/utils.ts
@@ -1135,19 +1135,21 @@ function handlePointerDown(ev: PointerEvent) {
   }
 
   if (keycap.variants) {
-    if (pressAndHoldTimer) clearTimeout(pressAndHoldTimer);
-    pressAndHoldTimer = setTimeout(() => {
-      if (target!.classList.contains('is-pressed')) {
-        target!.classList.remove('is-pressed');
-        target!.classList.add('is-active');
-        if (ev.target && 'releasePointerCapture' in ev.target)
-          (ev.target as HTMLElement).releasePointerCapture(ev.pointerId);
-        showVariantsPanel(target!, () => {
-          controller.abort();
-          target?.classList.remove('is-active');
-        });
-      }
-    }, 300);
+    pressAndHoldTimer = setTimeout(
+      () => {
+        if (target!.classList.contains('is-pressed')) {
+          target!.classList.remove('is-pressed');
+          target!.classList.add('is-active');
+          if (ev.target && 'releasePointerCapture' in ev.target)
+            (ev.target as HTMLElement).releasePointerCapture(ev.pointerId);
+          showVariantsPanel(target!, () => {
+            controller.abort();
+            target?.classList.remove('is-active');
+          });
+        }
+      },
+      keycap.popover ? 0 : 300
+    );
   }
 
   ev.preventDefault();

--- a/src/virtual-keyboard/utils.ts
+++ b/src/virtual-keyboard/utils.ts
@@ -1149,7 +1149,7 @@ function handlePointerDown(ev: PointerEvent) {
           });
         }
       },
-      keycap.popover ? 0 : 300
+      keycap.stickyVariantPanel ? 0 : 300
     );
   }
 

--- a/src/virtual-keyboard/utils.ts
+++ b/src/virtual-keyboard/utils.ts
@@ -1135,6 +1135,7 @@ function handlePointerDown(ev: PointerEvent) {
   }
 
   if (keycap.variants) {
+    if (pressAndHoldTimer) clearTimeout(pressAndHoldTimer);
     pressAndHoldTimer = setTimeout(
       () => {
         if (target!.classList.contains('is-pressed')) {

--- a/src/virtual-keyboard/variants.ts
+++ b/src/virtual-keyboard/variants.ts
@@ -292,7 +292,7 @@ export function showVariantsPanel(
         { capture: true, signal }
       );
 
-      if (keyboard.getKeycap(keycap?.id)?.popover) {
+      if (keyboard.getKeycap(keycap?.id)?.stickyVariantPanel) {
         window.addEventListener(
           'pointerdown',
           (ev) => {

--- a/src/virtual-keyboard/variants.ts
+++ b/src/virtual-keyboard/variants.ts
@@ -292,23 +292,37 @@ export function showVariantsPanel(
         { capture: true, signal }
       );
 
-      window.addEventListener(
-        'pointercancel',
-        () => {
-          hideVariantsPanel();
-          onClose?.();
-        },
-        { signal }
-      );
+      if (keyboard.getKeycap(keycap?.id)?.popover) {
+        window.addEventListener(
+          'pointerdown',
+          (ev) => {
+            if (!(ev.target instanceof Node)) return;
+            const isInside = variantPanel.contains(ev.target);
+            if (ev.target === variantPanel || isInside) return;
+            hideVariantsPanel();
+            onClose?.();
+          },
+          { signal }
+        );
+      } else {
+        window.addEventListener(
+          'pointercancel',
+          () => {
+            hideVariantsPanel();
+            onClose?.();
+          },
+          { signal }
+        );
 
-      window.addEventListener(
-        'pointerup',
-        () => {
-          hideVariantsPanel();
-          onClose?.();
-        },
-        { signal }
-      );
+        window.addEventListener(
+          'pointerup',
+          () => {
+            hideVariantsPanel();
+            onClose?.();
+          },
+          { signal }
+        );
+      }
     });
   }
 


### PR DESCRIPTION
fix #2549 

### Overview

This PR adds a `stickyVariantPanel` option to the VirtualKeyboardKeycap. When this option is enabled, clicking on a key with variants configured will display the Variants Panel without a long press. Additionally, the panel will not automatically hide.

The motivation for implementing this feature is described in #2549, and a similar request can be found in #2363.

### Notes

- Tests have not been added yet.
- Added an example: sticky-variant-panel/index.html.
- I am not entirely confident about the API naming.