### PR TITLE
Fix package.json subpath exports matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "./static.css": "./dist/mathlive-static.css",
     "./fonts/*": "./dist/fonts/*",
     "./sounds/*": "./dist/sounds/*",
-    "./fonts/": "./dist/fonts/*",
-    "./sounds/": "./dist/sounds/*"
+    "./fonts/": "./dist/fonts/",
+    "./sounds/": "./dist/sounds/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR updates subpath exports in the main package.json to comply with Node.js's [subpath patterns](https://nodejs.org/api/packages.html#subpath-patterns), which utilize "direct static matching and replacement."

As a result, it resolves issue #2550, where Mathlive could not be used with Next.js when Turbopack was enabled due to its strict code validation.