### PR TITLE
Only show focused prompt box when focused

### DIFF
--- a/css/mathfield.less
+++ b/css/mathfield.less
@@ -448,7 +448,7 @@ menu .ML__base {
   z-index: -1;
 }
 
-.ML__focusedPromptBox {
+.ML__focused .ML__focusedPromptBox {
   outline: highlight auto 1px;
 }
 


### PR DESCRIPTION
Fixed the issue that upon blur prompt box, there was still a surrounding outline box

Fixed result:

https://github.com/user-attachments/assets/bc148bf0-801a-4edc-9acc-66d9eba5eadf

