### PR TITLE
fix(virtual-keyboard): ignore blur event on touch devices

### DIFF
--- a/src/public/mathfield-element.ts
+++ b/src/public/mathfield-element.ts
@@ -1922,13 +1922,15 @@ import "https://unpkg.com/@cortex-js/compute-engine?module";
     // Ignore blur events if the scrim is open (case where the variant panel
     // is open), or if we're in an iFrame on a touch device (see #2350).
 
+    if (evt.type !== 'blur') return;
+
+    const touch = isTouchCapable();
+
+    if (touch && window?.mathVirtualKeyboard?.visible) return;
     // Otherwise we disconnect from the VK and end up in a weird state.
-    if (
-      evt.type === 'blur' &&
-      Scrim.scrim?.state === 'closed' &&
-      !(isTouchCapable() && isInIframe())
-    )
-      this._mathfield?.blur();
+    if (Scrim.scrim?.state !== 'closed' || (touch && isInIframe())) return;
+
+    this._mathfield?.blur();
   }
 
   /**


### PR DESCRIPTION
When using the virtual keyboard on mobile, typing
quickly would cause a blur event to be dispatched.
This change ignores the blur event in the mathfield
when a touch device is recognized and the virtual
keyboard is visible.

refs: #2254
