### PR TITLE
fixHidePopoverFail

### DIFF
--- a/src/ui/menu/menu-list.ts
+++ b/src/ui/menu/menu-list.ts
@@ -434,7 +434,13 @@ export class _MenuListState implements MenuListState {
     // Notify our parent
     if (this.parentMenu) this.parentMenu.openSubmenu = null;
 
-    if (supportPopover() && this._element?.popover) this.element.hidePopover();
+    if (supportPopover() && this._element?.popover) {
+      try {
+        this.element.hidePopover()
+      } catch (error) {
+        
+      };
+    }
 
     // We're going to do some focus manipulation, but we don't want parents
     // to react to these events (they may think the host has lost focus and


### PR DESCRIPTION
Fixed the issue on poor computers where the message "This might have been the result of the "beforetoggle" event handler changing the state of this popover." appears.

![image](https://github.com/user-attachments/assets/a4335a45-523a-471c-acb5-1b6cdad334ae)
This line reports an error, causing the subsequent code to not execute


<img width="391" alt="aa0c9459ac583068b9a20189a31cc4d" src="https://github.com/user-attachments/assets/3e93da18-22b2-482b-982d-4b353697f5aa" />
