### PR TITLE
Fixed \coloneq symbol in definitions-utils.ts

### DIFF
--- a/src/latex-commands/definitions-utils.ts
+++ b/src/latex-commands/definitions-utils.ts
@@ -297,8 +297,8 @@ const DEFAULT_MACROS: MacroDictionary = {
       coloneqq: '{\\mathop{\\char"2254}}', // ≔
       // \providecommand*\Coloneqq{\dblcolon\mathrel{\mkern-1.2mu}=}
       Coloneqq: '{\\mathop{\\char"2237\\char"3D}}',
-      // \providecommand*\coloneq{\vcentcolon\mathrel{\mkern-1.2mu}\mathrel{-}}
-      coloneq: '{\\mathop{\\char"3A\\char"2212}}',
+      // \providecommand*\coloneq{\vcentcolon\mathrel{\mkern-1.2mu}=}
+      coloneq: '{\\mathop{\\char"2254}}', // ≔
       // \providecommand*\Coloneq{\dblcolon\mathrel{\mkern-1.2mu}\mathrel{-}}
       Coloneq: '{\\mathop{\\char"2237\\char"2212}}',
       // \providecommand*\eqqcolon{=\mathrel{\mkern-1.2mu}\vcentcolon}


### PR DESCRIPTION
The issues was described in https://github.com/arnog/mathlive/issues/2574

Changes:
-fixed \colonq symbol to use the character `2245` which is the correct equivalent to `:=` (as used on the legacy  \coloneqq according to the current mathtools package: https://ftpmirror1.infania.net/mirror/CTAN/macros/latex/contrib/mathtools/mathtools.pdf