### PR TITLE
fix: formula text wiggles with caret movement

### DIFF
--- a/css/mathfield.less
+++ b/css/mathfield.less
@@ -228,6 +228,10 @@
 //   }
 // }
 
+.ML__caret {
+  display: inline-block;
+}
+
 .ML__caret::after {
   content: '';
   visibility: hidden;


### PR DESCRIPTION
- fix #2577

This pull request addresses the problem highlighted in issue #2577. The `ML__caret` element did not have a defined `display` property and was therefore implicitly treated as `display: inline`. By explicitly setting it to `inline-block`, the rendered formula elements remain static and no longer shift their positions when the caret moves.

I’ve attached videos demonstrating the behavior before and after this fix. Please refer to them for more details.

### before

https://github.com/user-attachments/assets/25b3aab5-5ec1-46d4-8018-46bd6a1f136e

### after

https://github.com/user-attachments/assets/5aadc6e4-b251-4025-94f0-a95fb18aa192