### PR TITLE
[FIX]: incorrect label for psi on virtual keyboard

### DIFF
--- a/src/virtual-keyboard/data.ts
+++ b/src/virtual-keyboard/data.ts
@@ -314,7 +314,7 @@ export const LAYOUTS: Partial<
           label: '<i>&psi;</i>',
           class: 'MLK__tex hide-shift',
           insert: '\\psi',
-          aside: 'zeta',
+          aside: 'psi',
           shift: '\\Psi',
         },
         {


### PR DESCRIPTION
Fixes #2590

As shown there, here's the bug:

![414047585-ca7ad38c-1dd3-481d-a9d7-09ba743aad12](https://github.com/user-attachments/assets/dd83d335-57f2-4a2d-b705-9deccb4d6a2c)

And here's the fixed screenshot!

![image](https://github.com/user-attachments/assets/8d78d9f6-df50-4f88-a30e-92328f6af4ba)

Just one line changed 👍 