### PR TITLE
fix: add virtual keyboard commands to the types

### DIFF
--- a/src/editor/keybindings-definitions.ts
+++ b/src/editor/keybindings-definitions.ts
@@ -1,4 +1,3 @@
-import { Selector } from '../public/commands';
 import type { Keybinding } from '../public/options';
 
 export const DEFAULT_KEYBINDINGS: Keybinding[] = [
@@ -229,7 +228,7 @@ export const DEFAULT_KEYBINDINGS: Keybinding[] = [
   // Accessibility
   { key: 'shift+alt+k', command: 'toggleKeystrokeCaption' },
   { key: 'alt+[Space]', command: 'toggleContextMenu' },
-  { key: 'alt+shift+[Space]', command: 'toggleVirtualKeyboard' as Selector },
+  { key: 'alt+shift+[Space]', command: 'toggleVirtualKeyboard' },
 
   // Note: On Mac OS (as of 10.12), there is a bug/behavior that causes
   // a beep to be generated with certain command+control key combinations.

--- a/src/public/commands.ts
+++ b/src/public/commands.ts
@@ -128,6 +128,10 @@ export interface Commands {
   toggleContextMenu: (mathfield: Mathfield) => boolean;
   toggleKeystrokeCaption: (mathfield: Mathfield) => boolean;
 
+  toggleVirtualKeyboard: (mathfield: Mathfield) => boolean;
+  showVirtualKeyboard: (mathfield: Mathfield) => boolean;
+  hideVirtualKeyboard: (mathfield: Mathfield) => boolean;
+
   plonk: (mathfield: Mathfield) => boolean;
 
   switchMode: (mathfield: Mathfield, mode: ParseMode) => boolean;


### PR DESCRIPTION
[`toggleVirtualKeyboard` is documented here](https://cortexjs.io/mathfield/guides/commands#user-interface), but trying to call `mf.executeCommand('toggleVirtualKeyboard')` results in type errors.

This change allows users to use `mf.executeCommand('toggleVirtualKeyboard')`, and the related `showVirtualKeyboard` and `hideVirtualKeyboard` without getting type errors.