### PR TITLE
docs: fix dead links to the cortexjs.io website

### DIFF
--- a/CHANGELOG_2017-2023.md
+++ b/CHANGELOG_2017-2023.md
@@ -259,7 +259,7 @@ mf.selection = mf.getPromptRange(id);
 
   The menu can be customized by setting the `mf.menuItems` property of the
   mathfield. The value of this property is an array of menu items. See
-  [the documentation](https://cortexjs.io/mathlive/guides/menus/) for details.
+  [the documentation](https://cortexjs.io/mathfield/guides/menu/) for details.
 
 ### Improvements
 
@@ -746,7 +746,7 @@ virtual keyboards and support for shift key modifier for many keycaps.
 
 - The JSON description of custom virtual keyboard now support keycap shortcuts.
   For example the `[left]` keycap shortcut represent the left arrow key. See the
-  [documentation](https://cortexjs.io/mathlive/guides/virtual-keyboards/#defining-custom-layouts)
+  [documentation](https://cortexjs.io/mathfield/guides/virtual-keyboard/#defining-custom-layouts)
   for more details.
 - Custom virtual keyboards can now include special keycaps for editing commands
   (cut/copy/paste/undo).
@@ -2082,7 +2082,7 @@ in order to preserve the same settings, you would now use:
   for example when inserting a fraction.
 - **#1389** Keyboard navigation inside tabular data (matrices, etc...)
 - Documentation: some of the data structures were not publicly exported and did
-  not appear in the documentation (https://cortexjs.io/docs/mathlive/)
+  not appear in the documentation (https://cortexjs.io/mathfield/api/)
 - When pasting content that included a double-backslash (e.g. as a row
   separator) immediately followed by a character, all double-backslash would be
   interpreted as a single backslash (this allowed pasting LaTeX that had been
@@ -2617,7 +2617,7 @@ Learn more at [cortexjs.io/math-json/](https://cortexjs.io/math-json/).
 - Added support for the `\displaylimits` command
 
 See
-[Supported TeX/LaTeX Commands](https://cortexjs.io/mathlive/reference/commands/)
+[Supported TeX/LaTeX Commands](https://cortexjs.io/mathfield/reference/commands/)
 for more details.
 
 ### Issues Resolved
@@ -2780,7 +2780,7 @@ for more details.
 - The default color mapping function now returns different values when used as a
   line color or as a background color. This improves the legibility of colors.
   See
-  [MathLive Guide: Customizing](https://cortexjs.io/mathlive/guides/customizing/).
+  [MathLive Guide: Customizing](https://cortexjs.io/mathfield/guides/customizing/).
 
 - Paste operations are now undoable.
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ You can also add it using CDN
 </head>
 ```
 
-Check documentation for [React](https://cortexjs.io/mathlive/guides/react/) and
-[interaction with Mathfield](https://cortexjs.io/mathlive/guides/interacting/).
+Check documentation for [React](https://cortexjs.io/mathfield/guides/react/) and
+[interaction with Mathfield](https://cortexjs.io/mathfield/guides/interacting/).
 
 ## 📖 Documentation
 
@@ -86,10 +86,10 @@ MathLive has an extensive set of documentation to help you get started,
 including guides on interacting with a mathfield, customizing it, executing
 commands, defining custom LaTeX macros, managing inline and keyboard shortcuts,
 controlling speech output, and displaying static math formulas. You can find all
-of these guides on the [CortexJS.io website](https://cortexjs.io/mathlive/).
+of these guides on the [CortexJS.io website](https://cortexjs.io/mathfield/).
 
 In addition to the guides, you can also find reference documentation of the
-MathLive API on the [MathLive SDK page](https://cortexjs.io/docs/mathlive).
+MathLive API on the [Mathfield API Reference page](https://cortexjs.io/mathfield/api/).
 
 ## FAQ
 

--- a/documentation/CONTRIBUTOR_GUIDE.md
+++ b/documentation/CONTRIBUTOR_GUIDE.md
@@ -2,7 +2,7 @@ This guide is for developers who want to contribute code to the project, or who
 need to modify or debug it.
 
 If you simply want to use MathLive in your project, see the
-[Getting Started](https://cortexjs.io/mathlive/guides/getting-started/) guide.
+[Getting Started](https://cortexjs.io/mathfield/guides/getting-started/) guide.
 
 ## Table of Contents
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,3 @@
 The `examples/` directory contain some ready to use examples using MathLive.
 
-For more examples, visit https://cortexjs.io/mathlive
+For more examples, visit https://cortexjs.io/mathfield

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -2,7 +2,7 @@
 
 This example shows how to interact with a MathLive mathfield.
 
-Read more at [MathLive Documentation](https://cortexjs.io/mathlive).
+Read more at [MathLive Documentation](https://cortexjs.io/mathfield).
 
 ES Modules, also known as JavaScript Modules, are the recommended way to load
 JavaScript libraries. The library is loaded asynchronously, improving loading

--- a/scripts/github-release.sh
+++ b/scripts/github-release.sh
@@ -33,7 +33,7 @@ VERSION=$(git describe --tags)
 
 # RELEASE_NOTE=$(sed -n '1,/^## /p' < CHANGELOG.md | sed '$d' | sed -e 's/$/\\n/' | sed -e 's/"/\\"/g' )
 
-RELEASE_NOTE="See [the Change Log](https://cortexjs.io/mathlive/changelog/)"
+RELEASE_NOTE="See [the Change Log](https://cortexjs.io/mathfield/changelog/)"
 
 API_JSON=$(printf '{"tag_name": "%s","target_commitish": "master","name": "%s","body": "%s","draft": false,"prerelease": false}' $VERSION $VERSION "$RELEASE_NOTE" )
 # echo $API_JSON


### PR DESCRIPTION
The website was updated a few months ago, with all MathLive URLs changing:
* `https://cortexjs.io/mathlive/` → `https://cortexjs.io/mathfield/`
* `https://cortexjs.io/docs/mathlive/` → `https://cortexjs.io/mathfield/api/`

All the old links now return 404, so this PR fixes those links. Would it be possible to also create some redirects from the old URLs?