### PR TITLE
fix: remove unnecessary `console.log`

### DIFF
--- a/src/editor-model/delete.ts
+++ b/src/editor-model/delete.ts
@@ -106,7 +106,6 @@ function onDelete(
   atom: Atom,
   branch?: Branch
 ): boolean {
-  console.log('onDelete', atom, branch);
   const parent = atom.parent;
 
   //


### PR DESCRIPTION
This was probably added for debug purposes, but it leaks to apps using mathlive, so it's probably best to remove it now.