### PR TITLE
Incorrect order of conditions for short-circuting.

### DIFF
--- a/src/editor-model/model-private.ts
+++ b/src/editor-model/model-private.ts
@@ -810,7 +810,7 @@ export class _Model implements Model {
   contentDidChange(options: ContentChangeOptions): void {
     if (window.mathVirtualKeyboard.visible)
       window.mathVirtualKeyboard.update(makeProxy(this.mathfield));
-    if (this.silenceNotifications || !this.mathfield.host || !this.mathfield)
+    if (this.silenceNotifications || !this.mathfield || !this.mathfield.host)
       return;
 
     const save = this.silenceNotifications;


### PR DESCRIPTION
In my project, I had an error triggered from within MathLive on this line:

`if (this.silenceNotifications || !this.mathfield.host || !this.mathfield)`

The code is pretty clearly trying to bail out if mathfield is absent, but because the check against mathfield is last, the line errors checking mathfield.host first. I swapped the order of the checks so that mathfield is checked first.