### PR TITLE
Fix: [CSS] Apply correct font to accent body

### DIFF
--- a/css/core.less
+++ b/css/core.less
@@ -330,9 +330,8 @@
   }
 }
 
-.ML__accent-body > span {
+.ML__accent-body {
   font-family: KaTeX_Main;
-  width: 0;
 }
 
 .ML__accent-combining-char {


### PR DESCRIPTION
Resolves #2647, resolves #2634, resolves #2562 

More details on the bug in #2647. As a summary, accents characters (such as \vec → and \hat ˆ) are showing incorrectly due to not using the correct font. 

There is an existing css rule that correctly applies the font only when the accent characters are in a nested span, which only occurs on selection. I've replaced that rule with a more general one that applies to all accents, and removed the obsolete `width: 0` attribute as well.

Other suggestions for solutions are welcome.