### PR TITLE
Fix colored text when MathField loses focus (fixes #2638, fixes #2479)

### DIFF
--- a/css/mathfield.less
+++ b/css/mathfield.less
@@ -308,7 +308,7 @@ with this style */
   color: var(--_smart-fence-color);
 }
 
-.ML__selected,
+.ML__focused .ML__selected,
 .ML__focused .ML__selected .ML__contains-caret,
 .ML__focused .ML__selected .ML__smart-fence__close,
 .ML__focused .ML__selected .ML__placeholder {


### PR DESCRIPTION
This correctly restores the color of text when a MathField element loses its focus