### PR TITLE
Resolve accidental trigger of menu items (fixes #2584)

### DIFF
--- a/src/editor-mathfield/mathfield-private.ts
+++ b/src/editor-mathfield/mathfield-private.ts
@@ -408,7 +408,7 @@ If you are using Vue, this may be because you are using the runtime-only build o
     const menuToggle =
       this.element!.querySelector<HTMLElement>('[part=menu-toggle]')!;
     menuToggle?.addEventListener(
-      'pointerdown',
+      'pointerup',
       (ev) => {
         if (ev.currentTarget !== menuToggle) return;
         const menu = this.menu;


### PR DESCRIPTION
Menu items in MathField are currently triggered by:

 * `pointerenter`
 * `pointerleave`
 * `pointerup`
 * `click`
 
However showing the menu is triggered using `pointerdown`.
 
Making both of these events consistent will avoid accidental triggering of menu items. This pull request resolves the issue by changing to `pointerup`, however you can also consider these alternative methods:

 1. Change the event to `click` if you would like both the down and up action to trigger on the menu toggle button
 2. Change the events in src/ui/menu/menu-item.ts to use `pointerdown` instead of `pointerup` and `click`