### PR TITLE
Change binding for Enter to accept suggestion and complete LaTeX mode

### DIFF
--- a/src/editor/keybindings-definitions.ts
+++ b/src/editor/keybindings-definitions.ts
@@ -73,8 +73,8 @@ export const DEFAULT_KEYBINDINGS: Keybinding[] = [
     ifMode: 'latex',
     command: ['complete', 'accept-suggestion'],
   }, // Complete the suggestion
-  { key: '[Return]', ifMode: 'latex', command: 'complete' },
-  { key: '[Enter]', ifMode: 'latex', command: 'complete' },
+  { key: '[Return]', ifMode: 'latex', command: ['complete', 'accept-all'] },
+  { key: '[Enter]', ifMode: 'latex', command: ['complete', 'accept-all'] },
   {
     key: 'shift+[Escape]',
     ifMode: 'latex',


### PR DESCRIPTION
Before:

[Screencast from 2025-03-31 13-26-42.webm](https://github.com/user-attachments/assets/569b17aa-571e-4222-b4e6-847e5e932869)

After:

[Screencast from 2025-03-31 13-27-22.webm](https://github.com/user-attachments/assets/204ddebd-cad1-4f0f-9651-8d5a0a636d8d)

I'm unsure if this is desired behavior. Myself and others who have used MathLive expected the Enter or Return key to accept the current suggestion and to leave LaTeX mode.

If undesired, perhaps there is a way to have this behavior? The `keybindings` property appears to be deprecated