### PR TITLE
Apply modal menu timer to child menu items (fixes #2584)

### DIFF
--- a/src/ui/menu/menu-item.ts
+++ b/src/ui/menu/menu-item.ts
@@ -349,13 +349,7 @@ export class _MenuItemState<T> implements MenuItemState<T> {
 
   handleEvent(event: Event): void {
     if (!this.visible || !this.enabled) return;
-
-    if (event.type === 'click') {
-      if (this.rootMenu.state === 'modal') this.select();
-      event.stopPropagation();
-      event.preventDefault();
-      return;
-    }
+    if (this.rootMenu.filterEvent(event)) return;
 
     if (event.type === 'pointerenter') {
       const ev = event as PointerEvent;
@@ -384,12 +378,9 @@ export class _MenuItemState<T> implements MenuItemState<T> {
         this.parentMenu.activeMenuItem = null;
       return;
     }
-
-    if (event.type === 'pointerup') {
-      // When modal, the items are activated on click,
-      // so ignore mouseup
-      if (this.rootMenu.state !== 'modal') this.select();
-
+    
+    if (event.type === 'click' || event.type === 'pointerup') {
+      this.select();
       event.stopPropagation();
       event.preventDefault();
       return;

--- a/src/ui/menu/menu.ts
+++ b/src/ui/menu/menu.ts
@@ -274,6 +274,28 @@ export class Menu extends _MenuListState implements RootMenuState {
     return this._host.dispatchEvent(ev);
   }
 
+  filterEvent(event: Event): boolean {
+    if (event.type === 'click' && this.state !== 'modal') {
+      event.stopPropagation();
+      event.preventDefault();
+      return true;
+    } else if (event.type === 'pointerup') {
+      if (
+        Number.isFinite(this.rootMenu._openTimestamp!) &&
+        Date.now() - this.rootMenu._openTimestamp! < 120
+      ) {
+        // "modal" = pointerdown + pointerup within 120ms : keep menu open
+        this.state = 'modal';
+      }
+      if (this.state === 'modal') {
+        event.stopPropagation();
+        event.preventDefault();
+        return true;
+      }
+    }
+    return false;
+  }
+
   get host(): HTMLElement | null {
     return this._host;
   }

--- a/src/ui/menu/private-types.ts
+++ b/src/ui/menu/private-types.ts
@@ -98,6 +98,7 @@ export interface RootMenuState extends MenuListState {
   state: 'closed' | 'open' | 'modal';
   readonly scrim: Element;
 
+  filterEvent(event: Event): boolean;
   cancelDelayedOperation(): void;
   scheduleOperation(op: () => void): void;
 }


### PR DESCRIPTION
MathField already has logic to trigger a modal menu if a pointerdown + pointerup occurs within 120 ms. However in some cases the menu items appear underneath the pointer, so the pointerup event will occur on a child menu item.

In this approach, child menu items pass their events through a `filterEvent` method on the root menu. The root menu has the option to make a decision about these events before allowing the child menu item to process them.

In this version, the modal logic is handled at the top-level. If a `pointerup` occurs too quickly, similar to the normal `handleEvent` logic, the root menu changes the state to `modal`. Then the logic varies as before, where `click` is expected for a modal child menu item, while `pointerup` is expected otherwise.

(Related: https://github.com/arnog/mathlive/pull/2661)

Perhaps it makes sense for the child menu itself to determine whether it should handle a `pointerup` or `click`, based on the `rootMenu.state` (as before), however it seemed appropriate that the menu should be the one to decide whether it should be in a `modal` state rather than an `open` state, and exposing the private timestamp variable also seemed inappropriate. There are a few ways this logic could be applied