### PR TITLE
Use capture to determine if context menu should be modal (fixes #2584)

### DIFF
--- a/src/ui/menu/menu.ts
+++ b/src/ui/menu/menu.ts
@@ -248,14 +248,14 @@ export class Menu extends _MenuListState implements RootMenuState {
       this.handleKeyupEvent(event as KeyboardEvent);
     else if (event.type === 'pointermove')
       this.lastMoveEvent = event as PointerEvent;
-    else if (event.type === 'pointerup' && event.target === this.scrim) {
+    else if (event.type === 'pointerup') {
       if (
         Number.isFinite(this.rootMenu._openTimestamp!) &&
         Date.now() - this.rootMenu._openTimestamp! < 120
       ) {
         // "modal" = pointerdown + pointerup within 120ms : keep menu open
         this.state = 'modal';
-      } else if (this.state === 'modal') {
+      } else if (this.state === 'modal' && event.target === this.scrim) {
         // Cancel
         this.hide();
       }
@@ -284,7 +284,7 @@ export class Menu extends _MenuListState implements RootMenuState {
 
   private connectScrim(target?: Node | null): void {
     const scrim = this.scrim!;
-    scrim.addEventListener('pointerup', this);
+    scrim.addEventListener('pointerup', this, true);
 
     scrim.addEventListener('contextmenu', this);
 
@@ -297,7 +297,7 @@ export class Menu extends _MenuListState implements RootMenuState {
 
   private disconnectScrim(): void {
     const scrim = this.scrim!;
-    scrim.removeEventListener('pointerup', this);
+    scrim.removeEventListener('pointerup', this, true);
 
     scrim.removeEventListener('contextmenu', this);
 


### PR DESCRIPTION
Use capture phase to ensure menu receives `pointerup` event before child menu items.

If `pointerdown` + `pointerup` < 120 ms, menu state should be modal

`pointerup` on scrim should hide menu

(Related: https://github.com/arnog/mathlive/pull/2661)