### PR TITLE
Move cursor to inside body of commands (like \sqrt) when first created

### DIFF
--- a/src/editor-mathfield/mode-editor-math.ts
+++ b/src/editor-mathfield/mode-editor-math.ts
@@ -360,7 +360,14 @@ export class MathModeEditor extends ModeEditor {
         const placeholderOffset = model.offsetOf(placeholder);
         model.setSelection(placeholderOffset - 1, placeholderOffset);
         model.announce('move'); // Should have placeholder selected
-      } else if (lastNewAtom) {
+      } else if (lastNewAtom?.body?.length) {
+        // Some commands have a body which behaves like a placeholder (such as square root)
+        const body = lastNewAtom.body;
+        model.setSelection(
+          model.offsetOf(body[0]),
+          model.offsetOf(body[body.length - 1]) + 1
+        );
+      } else {
         // No placeholder found, move to right after what we just inserted
         model.position = model.offsetOf(lastNewAtom);
       }


### PR DESCRIPTION
**Description**

Some commands (like \ang or \sqrt) have an inner body. When created, the cursor advances past the new created command. This change sets the selection to inside the command.

**Before**

[Screencast from 2025-04-03 08-33-03.webm](https://github.com/user-attachments/assets/4ffd20ee-15e9-4adf-90f7-696bb9cf584f)

**After**

[Screencast from 2025-04-03 08-33-36.webm](https://github.com/user-attachments/assets/74cb2323-0ecf-4be5-a273-684eac2f2e05)
