### PR TITLE
Use forced-color-adjust to fix high contrast mode (resolves #2482)

### DIFF
--- a/css/core.less
+++ b/css/core.less
@@ -260,6 +260,11 @@
             draw at some zoom levels, but setting the transform triggers
             the hardware accelerated path, which works */
     transform: translate(0, 0);
+    forced-color-adjust: preserve-parent-color;
+  }
+
+  @media (forced-colors: active) {
+    min-height: 0px;
   }
 }
 
@@ -291,6 +296,13 @@
             draw at some zoom levels, but setting the transform triggers
             the hardware accelerated path, which works */
     transform: translate(0, 0);
+    forced-color-adjust: preserve-parent-color;
+  }
+
+  @media (forced-colors: active) {
+    &:after {
+      background: white !important;
+    }
   }
 
   &:after {
@@ -377,6 +389,8 @@
   user-select: none;
 
   width: min-content;
+
+  forced-color-adjust: preserve-parent-color;
 
   .style-wrap {
     position: relative;

--- a/css/mathfield.less
+++ b/css/mathfield.less
@@ -110,6 +110,18 @@
   );
 }
 
+@media (forced-colors: active) {
+  .ML__container {
+    --_caret-color: white;
+    --_selection-color: white;
+    --_smart-fence-color: white;
+    --_latex-color: white;
+    --_correct-color: white;
+    --_incorrect-color: white;
+    --_composition-text-color: white;
+  }
+}
+
 // Prevent pointer-down event on touch devices if the host isn't focused
 // this allows scrolling if you touch unfocused fields
 @media (hover: none) and (pointer: coarse) {


### PR DESCRIPTION
When using a high contrast mode, a media mode called "forced-colors" is enabled. It forces most things to be either black or white. LaTeX symbols and the lines from fractions or square roots were invisible.

**Before**

![Screenshot from 2025-04-09 12-32-43](https://github.com/user-attachments/assets/4a86fe1d-f4a4-40c4-927b-f4657d66444b)

**After**

![Screenshot from 2025-04-09 12-31-14](https://github.com/user-attachments/assets/9654a706-b545-481c-a913-995c01bd2e81)

You can test by going to Dev Tools > ... > More tools > Rendering > Emulate CSS media feature forced-colors > forced-colors: active