### PR TITLE
Add 'suggestion-zindex' variable for suggestion popover (resolve #1579)

### DIFF
--- a/css/suggestion-popover.less
+++ b/css/suggestion-popover.less
@@ -7,12 +7,13 @@
 
 /* The element that display info while in latex mode */
 #mathlive-suggestion-popover {
+  --_suggestion-zindex: var(--suggestion-zindex, 100);
   background-color: rgba(97, 97, 97);
   color: #fff;
   text-align: center;
   border-radius: 8px;
   position: fixed;
-  z-index: 1;
+  z-index: var(--_suggestion-zindex);
 
   display: none;
   flex-direction: column;


### PR DESCRIPTION
Add a 'suggestion-zindex' CSS variable.

`keyboard-zindex` defaults to 105, this currently defaults to 100 to set behind the virtual keyboard, however in front of other elements