### PR TITLE
Add --text-shadow support (resolve #2592)

### DIFF
--- a/css/mathfield.less
+++ b/css/mathfield.less
@@ -156,6 +156,17 @@
      Weirdly, this is required for prompts to be rendered correctly. 
    */
   isolation: isolate;
+
+  text-shadow: var(--text-shadow);
+  .ML__latex {
+    text-shadow: var(--text-shadow);
+  }
+  .ML__sqrt-line {
+    box-shadow: var(--text-shadow);
+  }
+  .ML__frac-line {
+    box-shadow: var(--text-shadow);
+  }
 }
 
 .ML__virtual-keyboard-toggle,


### PR DESCRIPTION
This enables initial support for text-shadow.

In order to support the feature properly, this change applies a CSS variable called `--text-shadow` instead of using the normal `text-shadow` CSS property. Some elements (such as the upper line of a square root or the dividing line for a fraction) are implemented as blocks rather than text. 

This change applies the `--text-shadow` variable to both `text-shadow` or `box-shadow` depending upon the element to create a uniform appearance

![image](https://github.com/user-attachments/assets/3eb69cb6-98eb-4a84-9379-c1ad2a04fd0b)
