### PR TITLE
fix: Change the conditions for moving focus after entering a shortcut

### DIFF
--- a/src/editor-mathfield/mode-editor-math.ts
+++ b/src/editor-mathfield/mode-editor-math.ts
@@ -172,7 +172,7 @@ export class MathModeEditor extends ModeEditor {
     const data =
       typeof input === 'string'
         ? input
-        : globalThis.MathfieldElement.computeEngine?.box(input).latex ?? '';
+        : (globalThis.MathfieldElement.computeEngine?.box(input).latex ?? '');
 
     if (
       !options.silenceNotifications &&

--- a/src/editor-mathfield/mode-editor-math.ts
+++ b/src/editor-mathfield/mode-editor-math.ts
@@ -362,7 +362,8 @@ export class MathModeEditor extends ModeEditor {
         model.announce('move'); // Should have placeholder selected
       } else if (lastNewAtom) {
         const body = lastNewAtom.body;
-        if (body && body.length) {
+        const hadEmptyBody = lastNewAtom.hasEmptyBranch('body');
+        if (body && hadEmptyBody) {
           // Some commands have a body which behaves like a placeholder (such as square root)
           model.setSelection(
             model.offsetOf(body[0]),


### PR DESCRIPTION
fixed #2712 

### Overview

Changed to use `Atom.hasEmptyBranch(‘body’)` to determine the condition for moving focus to the body after entering a shortcut.

`\sqrt` and `\ang`, which were pointed out in #2671, now work correctly.

Other shortcuts do not seem to be affected, but please let me know if there are any problems.

https://github.com/user-attachments/assets/ff3c7124-b7be-4ede-a49f-3cbcdbfa7e23



