### PR TITLE
Protect resizeObserver.unobserve call

### DIFF
--- a/src/editor-mathfield/render.ts
+++ b/src/editor-mathfield/render.ts
@@ -22,7 +22,7 @@ export function requestUpdate(
   mathfield: _Mathfield | undefined | null,
   options?: { interactive: boolean }
 ): void {
-  if (!mathfield || mathfield.dirty) return;
+  if (!mathfield || mathfield.dirty || !mathfield.field) return;
   mathfield.resizeObserver.unobserve(mathfield.field);
   mathfield.dirty = true;
   requestAnimationFrame(() => {


### PR DESCRIPTION
In my project, I'm observing errors because mathfield.field is undefined in `mathfield.resizeObserver.unobserve(mathfield.field);` Given that the function already bails if mathfield is undefined, it seems it should do the same in mathfield.field is undefined.