### PR TITLE
fix: create separate atoms for each column of a row

### DIFF
--- a/src/atoms/array.ts
+++ b/src/atoms/array.ts
@@ -743,7 +743,9 @@ export class ArrayAtom extends Atom {
     this._rows.splice(
       row,
       0,
-      new Array(this.colCount).fill(makeEmptyCell(this, !this.isMultiline))
+      Array.from({ length: this.colCount }, () =>
+        makeEmptyCell(this, !this.isMultiline)
+      )
     );
     adjustBranches(this);
     this.isDirty = true;
@@ -755,7 +757,9 @@ export class ArrayAtom extends Atom {
     this._rows.splice(
       row + 1,
       0,
-      new Array(this.colCount).fill(makeEmptyCell(this, !this.isMultiline))
+      Array.from({ length: this.colCount }, () =>
+        makeEmptyCell(this, !this.isMultiline)
+      )
     );
 
     adjustBranches(this);


### PR DESCRIPTION
Array.fill calls the function once for the whole array, so if the environment has multiple columns you end up with multiple cells with the same reference which creates multiple carats for input

<img width="140" height="85" alt="image" src="https://github.com/user-attachments/assets/59da3d1f-2bb9-4a46-b4c6-636ab9740935" />
