### PR TITLE
fix: allow npm ci to run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.106.0",
       "license": "MIT",
       "dependencies": {
-        "@cortex-js/compute-engine": "0.28.0"
+        "@cortex-js/compute-engine": "0.29.1"
       },
       "devDependencies": {
         "@arnog/esbuild-plugin-less": "^1.1.0",
@@ -588,9 +588,9 @@
       "license": "MIT"
     },
     "node_modules/@cortex-js/compute-engine": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.28.0.tgz",
-      "integrity": "sha512-kGs74P4KVNLSqu+iVhLSAvodScZdVGoZI2kOsUjnBEFCFjlPJ1Nj5TpBz/4nwPT+viguB+g7VseXsmcxWRx23Q==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.29.1.tgz",
+      "integrity": "sha512-bCpaGW+Th+6lrTEDom3mNInfu3hu2N79FpUuqdVyvhE1Np4O447O/1gsgqLAFqVjg58cGN0FCAxf8gXkQNF4CQ==",
       "license": "MIT",
       "dependencies": {
         "complex-esm": "^2.1.1-esm1",


### PR DESCRIPTION
fixes this error in the pipeline/command line:
```
`npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
```