### PR TITLE
Include all macros when creating speakable text fragments

### DIFF
--- a/src/formats/atom-to-speakable-text.ts
+++ b/src/formats/atom-to-speakable-text.ts
@@ -500,9 +500,11 @@ function atomToSpeakableFragment(
       // Workaround: if the macro is expand = true, speak the atom body, otherwise speak the macro name
       const macroName = command.replace(/^\\/g, '');
       const macro = getMacros()[macroName];
-      if (macro) {
-        if (macro?.expand) result += atomToSpeakableFragment('math', atom.body);
-        else result += `${macroName} `;
+      if (macro?.expand) {
+        result += atomToSpeakableFragment('math', atom.body);
+      }
+      else {
+        result += `${macroName} `;
       }
       break;
     case 'placeholder':


### PR DESCRIPTION
Currently, if the lookup of a macro in `DEFAULT_MACROS` (for the purpose of checking if it should be expanded) fails, that macro is skipped entirely. That means that custom macros are not included in text-to-speech at all. 

I have changed the logic, so that the macro text is used as a fallback in cases where the macro cannot be looked up (e.g., a custom macro that's not in `DEFAULT_MACROS`. This provides better support for speaking custom macros until a more extensive customization feature gets added.