### PR TITLE
fix: corrected prompt vertical spacing to account for padding

### DIFF
--- a/src/atoms/prompt.ts
+++ b/src/atoms/prompt.ts
@@ -125,7 +125,7 @@ export class PromptAtom extends Atom {
     if (hPadding === 0) box.setStyle('width', '100%'); // @todo: remove
     if (hPadding !== 0) {
       box.setStyle('width', `calc(100% + ${2 * hPadding}em)`); // @todo: remove
-      box.setStyle('top', fboxsep, 'em'); // empirical
+      box.setStyle('top', fboxsep + vPadding, 'em'); // empirical
       box.setStyle('left', -hPadding, 'em');
     }
     // empty prompt should be a little wider

--- a/src/atoms/prompt.ts
+++ b/src/atoms/prompt.ts
@@ -160,7 +160,7 @@ export class PromptAtom extends Atom {
     result.left = hPadding;
     result.right = hPadding;
     result.setStyle('height', base.height + vPadding, 'em');
-    result.setStyle('top', base.depth - base.height, 'em');
+    result.setStyle('top', base.depth - base.height - vPadding/2, 'em');
     result.setStyle('vertical-align', base.depth + vPadding, 'em');
     result.setStyle('margin-left', 0.5, 'em');
     result.setStyle('margin-right', 0.5, 'em');


### PR DESCRIPTION
This pull requests aims at solving the incorrect spacing in prompts, where the prompt contents are not vertically centered.
The first fix simply adjusts the prompt position with respect to the content, taking into account also the vertical padding.

**With first fix:**
<img width="204" height="248" alt="image" src="https://github.com/user-attachments/assets/e7372099-2a63-40c3-841d-84003e48fdfb" />

**Without first fix:**
<img width="243" height="263" alt="image" src="https://github.com/user-attachments/assets/606e90a5-e8f2-4755-b839-7fce28a6de00" />

As we can see, after the first fix, the prompts are incorrectly spaced with respect to the fraction line. The second fix addresses this issue:

**With second fix:**
<img width="213" height="371" alt="image" src="https://github.com/user-attachments/assets/9c537a8f-659f-48be-9384-49f8a59f7e1b" />

**Without second fix:**
<img width="244" height="359" alt="image" src="https://github.com/user-attachments/assets/8bb0bd53-56ec-4579-b340-7ab07e0fe8a4" />

