### PR TITLE
Fix backspace trap after deleting lone latex backslash

### DIFF
--- a/src/editor-model/delete.ts
+++ b/src/editor-model/delete.ts
@@ -415,9 +415,21 @@ export function deleteBackward(model: _Model): boolean {
         return;
       }
 
+      const targetParent = target.parent!;
       model.position = model.offsetOf(target.leftSibling);
-      target.parent!.removeChild(target);
+      targetParent.removeChild(target);
       model.announce('delete', undefined, [target]);
+
+      // If deleting the last LaTeX atom leaves an empty LaTeX group, remove it
+      // so the caret is not trapped in command mode.
+      if (
+        targetParent.type === 'latexgroup' &&
+        targetParent.hasEmptyBranch('body')
+      ) {
+        const pos = model.offsetOf(targetParent.leftSibling);
+        targetParent.parent?.removeChild(targetParent);
+        model.position = Math.max(0, pos);
+      }
 
       // If the field is now empty, flush the inline shortcut buffer
       // to prevent stale shortcuts from being triggered (issue #2733)
@@ -466,7 +478,8 @@ export function deleteForward(model: _Model): boolean {
         return;
       }
 
-      target.parent!.removeChild(target);
+      const targetParent = target.parent!;
+      targetParent.removeChild(target);
       let sibling = model.at(model.position)?.rightSibling;
       while (sibling?.type === 'subsup') {
         sibling.parent!.removeChild(sibling);
@@ -474,6 +487,16 @@ export function deleteForward(model: _Model): boolean {
       }
 
       model.announce('delete', undefined, [target]);
+
+      // Same cleanup as backward delete: don't keep an empty LaTeX group.
+      if (
+        targetParent.type === 'latexgroup' &&
+        targetParent.hasEmptyBranch('body')
+      ) {
+        const pos = model.offsetOf(targetParent.leftSibling);
+        targetParent.parent?.removeChild(targetParent);
+        model.position = Math.max(0, pos);
+      }
 
       // If the field is now empty, flush the inline shortcut buffer
       // to prevent stale shortcuts from being triggered (issue #2733)

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -708,6 +708,20 @@ test('issue #2733: inline shortcut buffer should flush when field becomes empty'
   expect(latex).toBe('x');
 });
 
+test('backspace should not trap caret in empty latex group', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').pressSequentially('a\\');
+  await page.locator('#mf-1').press('Backspace');
+  await page.locator('#mf-1').press('Backspace');
+
+  const latex = await page
+    .locator('#mf-1')
+    .evaluate((mfe: MathfieldElement) => mfe.value);
+
+  expect(latex).toBe('');
+});
+
 async function tab(page) {
   await page.keyboard.press('Tab');
   // Wait some time for focus to change


### PR DESCRIPTION
Fixes a caret trap in LaTeX command mode after deleting a lone backslash (related to [#2871](https://github.com/arnog/mathlive/pull/2871)).

Repro: type a\, press Backspace (deletes \), then press Backspace again. Before this change, deletion/navigation could plonk because an empty latexgroup remained. This PR removes empty latexgroup containers when delete operations remove the last LaTeX atom, so the second Backspace correctly deletes a.

Compared with #2871’s targeted “last backslash” handling, this addresses the underlying structural issue in delete flow and applies to both backward/forward delete paths. Included regression test: backspace should not trap caret in empty latex group (test/playwright-tests/physical-keyboard.spec.ts).