### PR TITLE
Fix duplicate atoms created by setValue() with incomplete LaTeX

### DIFF
--- a/src/editor-model/model-private.ts
+++ b/src/editor-model/model-private.ts
@@ -933,11 +933,11 @@ function atomIsInRange(
   const firstChild = includeFirstAtoms
     ? atom.firstChild
     : firstNonFirstChild(atom);
-  if (!firstChild) return false;
+  if (!firstChild) return true;
   const lastChild = includeFirstAtoms
     ? atom.lastChild
     : lastNonFirstChild(atom);
-  if (!lastChild) return false;
+  if (!lastChild) return true;
 
   const firstOffset = model.offsetOf(firstChild);
   if (firstOffset >= first && firstOffset <= last) {


### PR DESCRIPTION
This pull requests aims at fixing a rendering/syncing issue, where  by useing setValue() calls with incomplete LaTeX (for example \sum_{ and similar constructs) could created duplicates.
The fix changes atomIsInRange() so atoms that are already offset-in-range are considered in-range even when no non-sentinel child exists.
This ensures deletion includes partially formed atoms created from incomplete LaTeX input, preventing accumulation across sync/update cycles.
![bug](https://github.com/user-attachments/assets/f1b9d7eb-ddf8-4f4d-b8c5-26c283611715)
