### PR TITLE
fix: Prevent virtual keyboard recursion in sandboxed iframe mathfields

### DIFF
--- a/src/virtual-keyboard/virtual-keyboard.ts
+++ b/src/virtual-keyboard/virtual-keyboard.ts
@@ -656,8 +656,8 @@ export class VirtualKeyboard implements VirtualKeyboardInterface, EventTarget {
       // don't handle it here (the iframe's mathfield will handle it)
       if (window === window.top && source !== window) return;
 
-      // Let the local mathfield's message listener handle non-keyboard
-      // commands to avoid re-sending them to the same window.
+      // If we're receiving our own message for a mathfield command,
+      // don't re-execute it here (the local mathfield will handle it)
       if (source === window && commandTarget !== 'virtual-keyboard') return;
 
       this.executeCommand(command!);

--- a/src/virtual-keyboard/virtual-keyboard.ts
+++ b/src/virtual-keyboard/virtual-keyboard.ts
@@ -656,9 +656,9 @@ export class VirtualKeyboard implements VirtualKeyboardInterface, EventTarget {
       // don't handle it here (the iframe's mathfield will handle it)
       if (window === window.top && source !== window) return;
 
-      // If we're in the top window and receiving our own message for a
-      // mathfield command, don't re-execute it (we already sent it)
-      if (window === window.top && commandTarget !== 'virtual-keyboard') return;
+      // Let the local mathfield's message listener handle non-keyboard
+      // commands to avoid re-sending them to the same window.
+      if (source === window && commandTarget !== 'virtual-keyboard') return;
 
       this.executeCommand(command!);
       return;

--- a/test/playwright-tests/virtual-keyboard.spec.ts
+++ b/test/playwright-tests/virtual-keyboard.spec.ts
@@ -161,6 +161,31 @@ test('math fields in iframe with virtual keyboard', async ({ page }) => {
   }
 });
 
+test('sandboxed iframe math field with virtual keyboard', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/iframe_test.html');
+
+  const frame = page.frame('mathlive-iframe-cross-origin');
+
+  expect(frame).toBeTruthy();
+
+  if (frame) {
+    await frame.locator('#mf-1').evaluate((mfe: MathfieldElement) => {
+      mfe.mathVirtualKeyboardPolicy = 'sandboxed';
+    });
+
+    await frame.locator('#mf-1').click();
+    await frame.locator('.ML__virtual-keyboard-toggle').nth(0).click();
+    await frame.locator('.MLK__layer.is-visible').waitFor();
+    await frame.getByRole('toolbar').getByText('abc').click();
+    await frame.locator('.MLK__layer.is-visible [aria-label="z"]').click();
+
+    const latex = await frame
+      .locator('#mf-1')
+      .evaluate((mfe: MathfieldElement) => mfe.value);
+    expect(latex).toBe('z');
+  }
+});
+
 test('Switch layer by shift', async ({ page }) => {
   await page.goto('/dist/playwright-test-page/');
 


### PR DESCRIPTION
fix #2931

## Summary

This PR fixes a virtual keyboard message loop for sandboxed mathfields inside cross-origin iframes.

In this setup, the iframe uses a real `VirtualKeyboard` instance instead of a proxy. When a mathfield command such as `insert` is sent through a `message` event, that same `VirtualKeyboard` instance can receive the command again and re-execute it. This causes repeated input and, in some cases, a stack overflow.

The fix is to make `VirtualKeyboard` re-handle only commands that are actually targeted at the virtual keyboard itself. Commands meant for the mathfield are left to the mathfield’s own message handler, which avoids the recursion.

## Testing

Added a Playwright regression test for a sandboxed mathfield inside a cross-origin iframe.

This test fails on current `master` with repeated input and passes with this patch.
