### PR TITLE
Add z-index to focused color in the colorpickers.

### DIFF
--- a/css/mathfield.less
+++ b/css/mathfield.less
@@ -651,6 +651,7 @@ menu .ML__base {
 
   &.active {
     background: var(--neutral-100);
+    z-index: 1;
     scale: 1.4;
     & > .label > span {
       border-radius: 2px;


### PR DESCRIPTION
Fixes stacking problem with the neighboring colors' background, which paints over the border of the active color.

Right now, it looks like this in the website:
<img width="614" height="392" alt="Screenshot 2026-04-22 190232" src="https://github.com/user-attachments/assets/de674a1e-e178-4eb2-993b-6ca1bef305b3" />

With the fix, it becomes like this:
<img width="899" height="573" alt="Screenshot 2026-04-22 204536" src="https://github.com/user-attachments/assets/f9337224-e40d-442a-8d85-8d8888a197a0" />
