### PR TITLE
Fix virtual keyboard safe area dupe

### DIFF
--- a/src/virtual-keyboard/virtual-keyboard.ts
+++ b/src/virtual-keyboard/virtual-keyboard.ts
@@ -354,7 +354,7 @@ export class VirtualKeyboard implements VirtualKeyboardInterface, EventTarget {
     if (this.container === document.body) {
       this._element.style.setProperty(
         '--_keyboard-height',
-        `calc(${h}px + var(--_padding-top) + var(--_padding-bottom) + env(safe-area-inset-bottom, 0))`
+        `calc(${h}px + var(--_padding-top) + var(--_padding-bottom))`
       );
       const keyboardHeight = h - 1;
       this.container!.style.paddingBottom = this.originalContainerBottomPadding


### PR DESCRIPTION
The --_padding-bottom variable already comprehends env(safe-area-inset-bottom). Adding it to the --_keyboard-height variable as well caused there to be twice as much empty space below the keyboard, in those contexts where safe areas are relevant.

Here's how it looks like in a mobile browser where the safe area is zero, because it's handled by the browser itself:
<img width="1080" height="965" alt="photo_2026-04-25_15-57-51" src="https://github.com/user-attachments/assets/568a7bc9-8f52-4af3-92e3-a33f3dd809df" />
and here's how it looks like on Android WebView, where safe areas are relevant:
<img width="1079" height="1052" alt="photo_2026-04-25_15-58-32" src="https://github.com/user-attachments/assets/dcc7b472-6b3f-4198-b9fc-9db4fa1ba01c" />
