### PR TITLE
Fix sync between keyboard and menu themes

### DIFF
--- a/src/ui/colors/colors.less
+++ b/src/ui/colors/colors.less
@@ -1,4 +1,5 @@
-:host {
+:host,
+:host([theme='light']) {
   --primary-color: #5898ff;
   --primary-color-dimmed: #c0c0f0;
   --primary-color-dark: var(--blue-500);


### PR DESCRIPTION
Specifying the theme attribute on the keyboard parent overrides the system theme. Specifying it on the mathfield does too, but only if it's "dark". Dark overrides light system theme, but not the other way around. This is because of selector specificity; the minimal change I made makes explicit light mode override more specific than the system dark mode.
This is system dark mode with explicit light mode override before:
<img width="385" height="393" alt="Screenshot 2026-04-28 093739" src="https://github.com/user-attachments/assets/513c7855-4180-47a4-938c-cdd74bc4bf8d" />
This is after:
<img width="431" height="375" alt="Screenshot 2026-04-28 092451" src="https://github.com/user-attachments/assets/e4275255-1bf6-4512-a167-341f9ccb5ecd" />
