### PR TITLE
Ensure a variant is set, otherwise font changes are ignored

### DIFF
--- a/src/core/modes-utils.ts
+++ b/src/core/modes-utils.ts
@@ -134,7 +134,7 @@ export function variantString(atom: Atom): string {
   if (!style) return '';
 
   let result = style.variant;
-  if (result === undefined) return 'normal';
+  if (result === undefined) result = 'normal';
 
   if (
     ![

--- a/src/editor-mathfield/styling.ts
+++ b/src/editor-mathfield/styling.ts
@@ -205,7 +205,7 @@ export function defaultInsertStyleHook(
 
   if (model.mode === 'math') {
     const atom = model.at(bias === 'right' ? info.after : info.before);
-    if (!atom) return mathfield.defaultStyle;
+    if (!atom) return { variant: 'normal', ...mathfield.defaultStyle };
     // Merge inherited style with defaultStyle, where defaultStyle takes precedence
     return { ...atom.style, variant: 'normal', ...mathfield.defaultStyle };
   }


### PR DESCRIPTION
This PR was made for issue: https://github.com/arnog/mathlive/issues/2963

Solution was generated by AI, so I will not pretend to have understood the code. The problem (according to the AI) is that texts don't have a variant: "normal", they may have variant: undefined and then setting the variant fails. This only happens for the first character (or first character in a "block"?).

This was tested against the reported issue.