### PR TITLE
Export math-static-elements.ts for using static element types

### DIFF
--- a/src/public/mathlive.ts
+++ b/src/public/mathlive.ts
@@ -42,6 +42,7 @@ export * from './mathfield';
 export * from './mathfield-element';
 export * from './mathlive-ssr';
 export * from './virtual-keyboard';
+export * from './math-static-elements';
 
 export declare function renderMathInDocument(
   options?: StaticRenderOptions


### PR DESCRIPTION
MathSpanElement (and related static element types) were not accessible from the public types, making it impossible to pass type check `mathSpanElement.render()` even if using TypeScript.

I added export * from './math-static-elements' to `src/public/mathlive.ts`.
This exposes MathSpanElement, MathDivElement so I can type-check references to <math-span> / <math-div> elements and call their methods without casting to any or unknown.

Example
```tsx
import type { MathSpanElement } from 'mathlive';
const mathSpanRef = useRef<MathSpanElement>(null);

mathSpanRef.current?.render();

return (<math-span ref={mathSpanRef} />);
```