### PR TITLE
Upgrade Compute Engine and Playwright

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.109.2",
       "license": "MIT",
       "dependencies": {
-        "@cortex-js/compute-engine": "0.55.6"
+        "@cortex-js/compute-engine": "0.58.0"
       },
       "devDependencies": {
         "@arnog/esbuild-plugin-less": "^1.1.0",
         "@cortex-js/prettier-config": "^1.2.0",
-        "@playwright/test": "^1.58.2",
+        "@playwright/test": "^1.60.0",
         "@types/jest": "^30.0.0",
         "@typescript-eslint/eslint-plugin": "^8.46.3",
         "@typescript-eslint/parser": "^8.26.1",
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/@arnog/colors": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@arnog/colors/-/colors-0.3.0.tgz",
-      "integrity": "sha512-CDZFMVWeE3HqcrzvacY2Y8257RS9c0f8+D+MWjbjmb5IWpOZPPeJSqWyxkVcFleCjA+x5aq6foc57cVaP+AMQg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@arnog/colors/-/colors-0.5.0.tgz",
+      "integrity": "sha512-NB7yqrO7qvInsqJdqz6C6mDU+2oiKmbBbk3czMS0E7KkGxLRy538tEHCsB5TKqmaxxXpi6/U120TnGl8NsDePg==",
       "license": "MIT"
     },
     "node_modules/@arnog/esbuild-plugin-less": {
@@ -581,12 +581,12 @@
       "license": "MIT"
     },
     "node_modules/@cortex-js/compute-engine": {
-      "version": "0.55.6",
-      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.55.6.tgz",
-      "integrity": "sha512-lWnZ34gtFpUDpFmEMdsL+5HJuh7hyj0DoaZhVTFnVtGX2Rf7qFyD+zgTs1vY9h2qhcpKymiakE6evvWzI6kwtA==",
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.58.0.tgz",
+      "integrity": "sha512-N0+vXjVZfKwJS7ZIGvq41mojI55m5TrdDXveAXzNjzjZ9iNiNrdEzXL2EmrcP+9GCWCwTonrEeZWAIG78f3INg==",
       "license": "MIT",
       "dependencies": {
-        "@arnog/colors": "^0.3.0",
+        "@arnog/colors": "^0.5.0",
         "complex-esm": "^2.1.1-esm1",
         "decimal.js": "^10.6.0"
       },
@@ -1962,13 +1962,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8958,13 +8958,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8977,9 +8977,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -128,12 +128,12 @@
   },
   "prettier": "@cortex-js/prettier-config",
   "dependencies": {
-    "@cortex-js/compute-engine": "0.55.6"
+    "@cortex-js/compute-engine": "0.58.0"
   },
   "devDependencies": {
     "@arnog/esbuild-plugin-less": "^1.1.0",
     "@cortex-js/prettier-config": "^1.2.0",
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.60.0",
     "@types/jest": "^30.0.0",
     "@typescript-eslint/eslint-plugin": "^8.46.3",
     "@typescript-eslint/parser": "^8.26.1",

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -483,11 +483,11 @@ test('keyboard cut and paste', async ({ page, browserName }) => {
   const modifierKey = process.platform === 'darwin' ? 'Meta' : 'Control';
 
   // On macOS, Cmd+A doesn't trigger select-all in Playwright's bundled
-  // Chromium/Firefox (both spoof a Win32 user agent). Use Ctrl+A instead;
-  // it works in Playwright on Mac and is the standard select-all on other
-  // platforms. Cmd+A works correctly in real Chrome/Edge/Firefox on Mac.
+  // Chromium. Use Ctrl+A instead; it works in Playwright on Mac and is the
+  // standard select-all on other platforms. Cmd+A works correctly in real
+  // Chrome/Edge on Mac and in Playwright's bundled Firefox.
   const selectAllCommand =
-    modifierKey === 'Meta' && (browserName === 'chromium' || browserName === 'firefox')
+    modifierKey === 'Meta' && browserName === 'chromium'
       ? 'Control+a'
       : `${modifierKey}+a`;
 


### PR DESCRIPTION
This PR upgrades `@cortex-js/compute-engine` to its latest version.

While trying to run tests, I ran into https://github.com/microsoft/playwright/issues/40724, and so I upgraded Playwright as well. Doing so revealed an issue in `test/playwright-tests/physical-keyboard.spec.ts`, which I addressed. After all of this, the tests passed for me locally.