### PR TITLE
feat: add macros option to validateLatex

### DIFF
--- a/src/public/mathlive-ssr.ts
+++ b/src/public/mathlive-ssr.ts
@@ -33,6 +33,7 @@ import '../core/modes';
 import { getDefaultContext } from '../core/context-utils';
 import { applyInterBoxSpacing } from '../core/inter-box-spacing';
 import { LayoutOptions } from './options';
+import { MacroDictionary } from './core-types';
 import { ContextInterface } from 'core/types';
 import {
   getMacroDefinition,
@@ -151,10 +152,28 @@ export function convertLatexToMarkup(
 /**
  * Check if a string of LaTeX is valid and return an array of syntax errors.
  *
+ * @param options.macros - Additional macro definitions to recognize during
+ * validation. These extend (not replace) the default macros. Useful for
+ * commands that MathLive renders correctly but are not part of its built-in
+ * command set (e.g. `\newline`).
+ *
+ * @example
+ * validateLatex('\\newline', { macros: { newline: '' } }); // returns []
+ *
  * @category Conversion
  */
-export function validateLatex(s: string): LatexSyntaxError[] {
-  return validateLatexInternal(s, { context: getDefaultContext() });
+export function validateLatex(
+  s: string,
+  options?: { macros?: MacroDictionary }
+): LatexSyntaxError[] {
+  const from = getDefaultContext();
+  if (options?.macros) {
+    const extraMacros = normalizeMacroDictionary(options.macros);
+    const baseMacro = from.getMacro!;
+    from.getMacro = (token) =>
+      getMacroDefinition(token, extraMacros) ?? baseMacro(token);
+  }
+  return validateLatexInternal(s, { context: from });
 }
 
 /**


### PR DESCRIPTION
## Problem

`validateLatex` has no way to declare commands that MathLive renders correctly but are not part of its built-in command set. For example, `\newline` is commonly used in math expressions and rendered without issue by `MathfieldElement`, but `validateLatex` flags it as `unknown-command` with no way to suppress it.

## Solution

Add an optional `macros` parameter to `validateLatex`, following the same pattern already used by `convertLatexToMarkup`. The extra macros **extend** (not replace) the default macro set, so callers only need to declare the additional commands they want to allow.

```ts
validateLatex('\\newline', { macros: { newline: '' } }); // returns []
validateLatex('\\frac{1}{2}');                           // still works
```

## Implementation

The change mirrors the existing macro-injection logic in `convertLatexToMarkup`:

1. `getDefaultContext()` produces the base context (with all default macros).
2. If `options.macros` is provided, `normalizeMacroDictionary` normalises it and the context's `getMacro` is chained: extra macros are checked first, then the base resolver handles everything else.
3. The enriched context is passed to `validateLatexInternal`.

Calling `validateLatex(s)` without options is identical to before.