### PR TITLE
feat: expose macros option on validateLatex

### DIFF
--- a/src/api.md
+++ b/src/api.md
@@ -6371,7 +6371,7 @@ convertMathJsonToLatex(["Add", 1, 2]);
 ### validateLatex()
 
 ```ts
-function validateLatex(s): LatexSyntaxError[]
+function validateLatex(s, options?): LatexSyntaxError[]
 ```
 
 Check if a string of LaTeX is valid and return an array of syntax errors.
@@ -6379,6 +6379,10 @@ Check if a string of LaTeX is valid and return an array of syntax errors.
 ##### s
 
 `string`
+
+##### options?
+
+`Pick`\<[`LayoutOptions`](#layoutoptions), `"macros"`\>
 
 </MemberCard>
 

--- a/src/public/mathlive-ssr.ts
+++ b/src/public/mathlive-ssr.ts
@@ -151,10 +151,19 @@ export function convertLatexToMarkup(
 /**
  * Check if a string of LaTeX is valid and return an array of syntax errors.
  *
+ * @param options.macros Custom macro definitions to recognize during validation.
  * @category Conversion
  */
-export function validateLatex(s: string): LatexSyntaxError[] {
-  return validateLatexInternal(s, { context: getDefaultContext() });
+export function validateLatex(
+  s: string,
+  options?: Pick<LayoutOptions, 'macros'>
+): LatexSyntaxError[] {
+  const context = { ...getDefaultContext() };
+  if (options?.macros) {
+    const macros = normalizeMacroDictionary(options.macros);
+    context.getMacro = (token) => getMacroDefinition(token, macros);
+  }
+  return validateLatexInternal(s, { context });
 }
 
 /**

--- a/test/latex.test.ts
+++ b/test/latex.test.ts
@@ -161,6 +161,23 @@ describe('MATHRM SERIALIZATION (issue #2818)', () => {
   });
 });
 
+describe('VALIDATE LATEX WITH MACROS', () => {
+  test('custom macro is not flagged as unknown', () => {
+    const errors = validateLatex('\\plimsoll', { macros: { plimsoll: '⦵' } });
+    expect(errors).toHaveLength(0);
+  });
+
+  test('unknown command is still flagged without macros', () => {
+    const errors = validateLatex('\\unknowncmd');
+    expect(errors).toStrictEqual([expect.objectContaining({ code: 'unknown-command' })]);
+  });
+
+  test('unknown command is still flagged even with unrelated macros', () => {
+    const errors = validateLatex('\\unknowncmd', { macros: { plimsoll: '⦵' } });
+    expect(errors).toStrictEqual([expect.objectContaining({ code: 'unknown-command' })]);
+  });
+});
+
 describe('REST* ARGUMENT COMMANDS (issue #2570)', () => {
   // Commands with {:rest*} deferred arguments should handle braced arguments
   test.each([


### PR DESCRIPTION
Currently, the function `validateLatex` exposed in the public API accepts no options parameter, which makes it impossible to receive custom arguments and use it to validate expressions containing user-defined commands, causing false-positive `unknown-command` errors.

This PR adds an optional `macros` parameter to `validateLatex` and wires it through to the internal parser context, just like `convertLatexToMarkup` already does, allowing the user to pass custom macros when validating expressions with user-defined commands.
