### PR TITLE
add MathfieldElement.compactFractionSerialization option

### DIFF
--- a/src/api.md
+++ b/src/api.md
@@ -803,6 +803,26 @@ manually.
 
 </MemberCard>
 
+<MemberCard>
+
+##### MathfieldElement.compactFractionSerialization
+
+```ts
+get static compactFractionSerialization(): boolean
+set static compactFractionSerialization(value: boolean): void
+```
+
+When `true` (the default), fractions whose numerator and denominator
+are both single digits are serialized in a compact form, e.g.
+`\frac12`.
+
+When `false`, fractions are always serialized with explicit braces,
+e.g. `\frac{1}{2}`.
+
+**Default**: `true`
+
+</MemberCard>
+
 #### Styles
 
 <MemberCard>

--- a/src/core/math-environment.ts
+++ b/src/core/math-environment.ts
@@ -3,6 +3,8 @@
  */
 export const _MathEnvironment: {
   fractionNavigationOrder: 'denominator-numerator' | 'numerator-denominator';
+  compactFractionSerialization: boolean;
 } = {
   fractionNavigationOrder: 'numerator-denominator',
+  compactFractionSerialization: true,
 };

--- a/src/latex-commands/functions.ts
+++ b/src/latex-commands/functions.ts
@@ -1,4 +1,5 @@
 import { joinLatex, latexCommand } from '../core/tokenizer';
+import { _MathEnvironment } from '../core/math-environment';
 
 import { Atom } from '../core/atom-class';
 import { ExtensibleSymbolAtom } from '../atoms/extensible-symbol';
@@ -199,11 +200,15 @@ defineFunction(
     serialize: (atom, options) => {
       const numer = atom.aboveToLatex(options);
       const denom = atom.belowToLatex(options);
-      // Special case serialization when numer and denom are digits
-      if (/^[0-9]$/.test(numer) && /^[0-9]$/.test(denom))
-        // We used to serialize as `\frac{3}{4}` as \frac34, but
-        // some people got confused by this, so we now serialize it as `\frac{3}{4}`.
-        // See a discussion on this topic here: https://tex.stackexchange.com/questions/82329/how-bad-for-tex-is-omitting-braces-even-if-the-result-is-the-same
+      // Special case serialization when numer and denom are digits:
+      // serialize `\frac{3}{4}` as `\frac34`, unless compact serialization
+      // has been turned off (some people find the compact form confusing).
+      // See a discussion on this topic here: https://tex.stackexchange.com/questions/82329/how-bad-for-tex-is-omitting-braces-even-if-the-result-is-the-same
+      if (
+        _MathEnvironment.compactFractionSerialization &&
+        /^[0-9]$/.test(numer) &&
+        /^[0-9]$/.test(denom)
+      )
         return `${atom.command}${numer}${denom}`;
 
       return latexCommand(atom.command, numer, denom);

--- a/src/public/mathfield-element.ts
+++ b/src/public/mathfield-element.ts
@@ -1083,6 +1083,24 @@ export class MathfieldElement extends HTMLElement implements Mathfield {
   }
 
   /**
+   * When `true` (the default), fractions whose numerator and denominator
+   * are both single digits are serialized in a compact form, e.g.
+   * `\frac12`.
+   *
+   * When `false`, fractions are always serialized with explicit braces,
+   * e.g. `\frac{1}{2}`.
+   *
+   * **Default**: `true`
+   * @category Customization
+   */
+  static get compactFractionSerialization(): boolean {
+    return _MathEnvironment.compactFractionSerialization;
+  }
+  static set compactFractionSerialization(value: boolean) {
+    _MathEnvironment.compactFractionSerialization = Boolean(value);
+  }
+
+  /**
    * A custom compute engine instance. If none is provided, a default one is
    * used. If `null` is specified, no compute engine is used.
    */

--- a/test/frac-serialization.test.ts
+++ b/test/frac-serialization.test.ts
@@ -1,0 +1,27 @@
+import '../src/public/mathlive-ssr';
+import { parseLatex } from '../src/core/parser';
+import { Atom } from '../src/core/atom-class';
+import { _MathEnvironment } from '../src/core/math-environment';
+
+function roundtrip(latex: string): string {
+  const atoms = parseLatex(latex, { parseMode: 'math' });
+  // Discard verbatim LaTeX so the serializer logic is exercised
+  for (const atom of atoms) atom.verbatimLatex = undefined;
+  return Atom.serialize(atoms, { defaultMode: 'math' });
+}
+
+describe('fraction serialization', () => {
+  afterEach(() => {
+    _MathEnvironment.compactFractionSerialization = true;
+  });
+
+  test('compact (default)', () => {
+    expect(roundtrip('\\frac{1}{2}')).toBe('\\frac12');
+  });
+
+  test('explicit braces when compactFractionSerialization is false', () => {
+    _MathEnvironment.compactFractionSerialization = false;
+    expect(roundtrip('\\frac{1}{2}')).toBe('\\frac{1}{2}');
+    expect(roundtrip('\\frac{12}{2}')).toBe('\\frac{12}{2}');
+  });
+});


### PR DESCRIPTION
When set to false, fractions with single-digit numerator and denominator are serialized with explicit braces (`\frac{1}{2}`) instead of the compact form (`\frac12`).

Defaults to `true`, preserving the existing behavior.