### PR TITLE
Add configurable piecewise and bounded operator shortcuts

### DIFF
--- a/css/virtual-keyboard.less
+++ b/css/virtual-keyboard.less
@@ -433,6 +433,15 @@ body > .ML__keyboard.is-visible.animate > .MLK__backdrop {
     font-size: var(--_keycap-small-font-size);
   }
 
+  // Use for keycaps with tall structured labels (for example, a two-row
+  // piecewise template) that need to fit inside the standard key height.
+  .compact {
+    .ML__latex {
+      transform: scale(0.72);
+      transform-origin: center;
+    }
+  }
+
   /* For the alignment of the text on some modifiers (e.g. shift) */
   .bottom {
     justify-content: flex-end;

--- a/src/api.md
+++ b/src/api.md
@@ -5159,6 +5159,7 @@ CSS classes to apply to the keycap.
    define the label.
 - `shift`: a shift key
 - `small`: display the label in a smaller size
+- `compact`: scale a structured label to fit inside the keycap
 - `action`: an “action” keycap (for arrows, return, etc…)
 - `separator w5`: a half-width blank used as a separator. Other widths
    include `w15` (1.5 width), `w20` (double width) and `w50` (five-wide,

--- a/src/atoms/bounded-argument.ts
+++ b/src/atoms/bounded-argument.ts
@@ -1,0 +1,36 @@
+import type { ParseMode, Style } from '../public/core-types';
+import type { Context } from '../core/context';
+import { Atom } from '../core/atom-class';
+import type { Box } from '../core/box';
+import type { ToLatexOptions } from 'core/types';
+import { PlaceholderAtom } from './placeholder';
+import { PromptAtom } from './prompt';
+
+/**
+ * A bound that behaves like ordinary content while retaining an empty slot
+ * when its last character is deleted. This keeps typed bounded operators as
+ * editable as MathLive's `#?` templates without drawing a prompt box around
+ * the initial argument.
+ */
+export class BoundedArgumentAtom extends PromptAtom {
+  constructor(body: readonly Atom[], options?: { mode?: ParseMode; style?: Style }) {
+    super(undefined, undefined, false, body, options);
+    // Keep this as an ordinary editable math atom for navigation/deletion;
+    // the PromptAtom base only supplies the branch/body machinery.
+    this.type = 'mord';
+    this.captureSelection = false;
+  }
+
+  render(context: Context): Box | null {
+    const hasContent = this.body?.some((atom) => atom.type !== 'first') ?? false;
+    const box = hasContent
+      ? Atom.createBox(context, this.body)
+      : new PlaceholderAtom({ mode: this.mode, style: this.style }).render(context);
+    return box ? this.bind(context, box) : null;
+  }
+
+  _serialize(options: ToLatexOptions): string {
+    const hasContent = this.body?.some((atom) => atom.type !== 'first') ?? false;
+    return hasContent ? this.bodyToLatex(options) : '\\placeholder{}';
+  }
+}

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -1762,6 +1762,7 @@ export class Parser {
     if (
       result instanceof Atom &&
       result.verbatimLatex === undefined &&
+      (info.definitionType !== 'function' || !info.parse) &&
       !/^\\(llap|rlap|class|cssId|htmlData)$/.test(command)
     ) {
       // We have to use `joinLatex` to correctly handle the case of

--- a/src/editor-mathfield/mode-editor-math.ts
+++ b/src/editor-mathfield/mode-editor-math.ts
@@ -23,6 +23,20 @@ import { _Mathfield } from './mathfield-private';
 import { ModeEditor } from './mode-editor';
 import type { AtomJson } from 'core/types';
 
+/**
+ * A row separator inserted as `\\` can be interpreted as the editor's
+ * immediate "insert row" command instead of as part of a larger structured
+ * template. Normalize cases templates to the equivalent `\\cr` token before
+ * parsing so virtual-keyboard insertion is deterministic.
+ */
+function normalizeCasesRowSeparators(latex: string): string {
+  return latex.replace(
+    /\\begin\\{(cases|dcases|rcases)\\}([\\s\\S]*?)\\end\\{\\1\\}/g,
+    (_match, name: string, body: string) =>
+      `\\begin{${name}}${body.replace(/\\\\/g, '\\\\cr')}\\end{${name}}`
+  );
+}
+
 export class MathModeEditor extends ModeEditor {
   constructor() {
     super('math');
@@ -464,6 +478,8 @@ function convertStringToAtoms(
         inlineShortcuts: model.mathfield.options.inlineShortcuts,
       });
     }
+
+    if (typeof s === 'string') s = normalizeCasesRowSeparators(s);
 
     // If the whole string is bracketed by a mode shift command, remove it
     if (options.format === 'latex') [, s] = trimModeShiftCommand(s);

--- a/src/editor-model/delete.ts
+++ b/src/editor-model/delete.ts
@@ -11,6 +11,32 @@ import { ArrayAtom } from 'atoms/array';
 import { PlaceholderAtom } from 'atoms/placeholder';
 import { BoundedArgumentAtom } from 'atoms/bounded-argument';
 
+function isEmptyBoundedOperator(atom: Atom | undefined): atom is Atom {
+  if (!atom || atom.type !== 'extensible-symbol') return false;
+
+  const boundedSlots = (atom as Atom & {
+    boundedArgumentSlots?: { subscript?: boolean; superscript?: boolean };
+  }).boundedArgumentSlots;
+  const isEmptySlot = (branch: 'subscript' | 'superscript') => {
+    const children = atom.branch(branch);
+    if (!children || children.length !== 2) return false;
+    const argument = children[1];
+    return (
+      argument instanceof PlaceholderAtom ||
+      (argument instanceof BoundedArgumentAtom &&
+        argument.body?.length === 2 &&
+        argument.body[1] instanceof PlaceholderAtom)
+    );
+  };
+
+  return Boolean(
+    boundedSlots?.subscript &&
+      boundedSlots.superscript &&
+      isEmptySlot('subscript') &&
+      isEmptySlot('superscript'),
+  );
+}
+
 // import {
 //     arrayFirstCellByRow,
 //     arrayColRow,
@@ -419,6 +445,22 @@ export function deleteBackward(model: _Model): boolean {
       if (target && onDelete(model, 'backward', target)) return;
 
       if (target?.isFirstSibling) {
+        // A bounded command keeps placeholder branches after its contents are
+        // deleted. Once navigation has reached the leading sentinel, the
+        // next Backspace should remove that now-empty operator instead of
+        // being mistaken for a no-op at the start of the containing branch.
+        const next = target.rightSibling;
+        if (isEmptyBoundedOperator(next)) {
+          const parent = next.parent;
+          if (parent) {
+            const position = model.offsetOf(next.leftSibling);
+            parent.removeChild(next);
+            model.position = position;
+            model.announce('delete', undefined, [next]);
+            return;
+          }
+        }
+
         if (onDelete(model, 'backward', target.parent!, target.parentBranch))
           return;
 

--- a/src/editor-model/delete.ts
+++ b/src/editor-model/delete.ts
@@ -8,6 +8,8 @@ import { MathfieldElement } from 'public/mathfield-element';
 import type { Branch } from 'core/types';
 import type { Range } from 'public/core-types';
 import { ArrayAtom } from 'atoms/array';
+import { PlaceholderAtom } from 'atoms/placeholder';
+import { BoundedArgumentAtom } from 'atoms/bounded-argument';
 
 // import {
 //     arrayFirstCellByRow,
@@ -301,6 +303,20 @@ function onDelete(
 
     // Check if branch is empty and handle removal before navigation
     if (branch && atom.hasEmptyBranch(branch)) {
+      const boundedSlots = (atom as Atom & {
+        boundedArgumentSlots?: { subscript?: boolean; superscript?: boolean };
+      }).boundedArgumentSlots;
+      if (
+        boundedSlots &&
+        ((branch === 'subscript' && boundedSlots.subscript) ||
+          (branch === 'superscript' && boundedSlots.superscript))
+      ) {
+        // Keep a visible editable slot for the bounded-command form after
+        // its last character is deleted.
+        atom.setChildren([new PlaceholderAtom()], branch);
+        model.position = model.offsetOf(atom.firstChild);
+        return true;
+      }
       atom.removeBranch(branch);
       if (atom.type === 'subsup' && !atom.subscript && !atom.superscript) {
         // We've removed the last branch of a subsup
@@ -416,8 +432,27 @@ export function deleteBackward(model: _Model): boolean {
       }
 
       const targetParent = target.parent!;
+      const deletedBranch = target.parentBranch;
       model.position = model.offsetOf(target.leftSibling);
       targetParent.removeChild(target);
+      if (
+        targetParent instanceof BoundedArgumentAtom &&
+        targetParent.hasEmptyBranch('body')
+      ) {
+        targetParent.setChildren([new PlaceholderAtom()], 'body');
+      }
+      const boundedSlots = (targetParent as Atom & {
+        boundedArgumentSlots?: { subscript?: boolean; superscript?: boolean };
+      }).boundedArgumentSlots;
+      if (
+        boundedSlots &&
+        (deletedBranch === 'subscript' || deletedBranch === 'superscript') &&
+        ((deletedBranch === 'subscript' && boundedSlots.subscript) ||
+          (deletedBranch === 'superscript' && boundedSlots.superscript)) &&
+        targetParent.hasEmptyBranch(deletedBranch)
+      ) {
+        targetParent.setChildren([new PlaceholderAtom()], deletedBranch);
+      }
       model.announce('delete', undefined, [target]);
 
       // If deleting the last LaTeX atom leaves an empty LaTeX group, remove it

--- a/src/editor/keybindings-definitions.ts
+++ b/src/editor/keybindings-definitions.ts
@@ -68,10 +68,20 @@ export const DEFAULT_KEYBINDINGS: Keybinding[] = [
     ifMode: 'math',
     command: ['switchMode', 'latex', '', '\\'],
   },
+  {
+    key: '\\',
+    ifMode: 'text',
+    command: ['switchMode', 'latex', '', '\\'],
+  },
   // { key: '[Backslash]', ifMode: 'math', command: ['switchMode', 'latex'] },
   {
     key: '[IntlBackslash]',
     ifMode: 'math',
+    command: ['switchMode', 'latex', '', '\\'],
+  }, // On UK QWERTY keyboards
+  {
+    key: '[IntlBackslash]',
+    ifMode: 'text',
     command: ['switchMode', 'latex', '', '\\'],
   }, // On UK QWERTY keyboards
 

--- a/src/latex-commands/environments.ts
+++ b/src/latex-commands/environments.ts
@@ -2,6 +2,7 @@ import type { Dimension, Environment } from '../public/core-types';
 
 import { Atom } from '../core/atom-class';
 import { ArrayAtom, ColumnFormat } from '../atoms/array';
+import { PlaceholderAtom } from '../atoms/placeholder';
 
 import {
   defineFunction,
@@ -226,6 +227,47 @@ defineTabularEnvironment(
 //   \def\arraystretch{1.2}%
 //   \array{@{}l@{\quad}l@{}}%
 defineTabularEnvironment(['cases', 'dcases', 'rcases'], '', makeEnvironment);
+
+/**
+ * Insert a piecewise function with a specified number of editable rows.
+ *
+ * `\piecewise{n}` is an input convenience command. It creates the same
+ * native array structure as `\begin{cases}...\end{cases}`, with two
+ * placeholders in each row (the expression and its condition).
+ */
+const MAX_PIECEWISE_ROWS = 100;
+
+defineFunction('piecewise', '{count:string}', {
+  parse: (parser: Parser) => {
+    const count = parser.scanArgument('string')?.trim() ?? '';
+    if (count.length === 0) {
+      parser.onError({ code: 'missing-argument', arg: '\\piecewise' });
+      return ['1'];
+    }
+
+    if (!/^[1-9]\d*$/.test(count) || Number(count) > MAX_PIECEWISE_ROWS) {
+      parser.onError({ code: 'unexpected-token', arg: count });
+      return ['1'];
+    }
+
+    return [count];
+  },
+  createAtom: (options) => {
+    const count = Number.parseInt(options.args?.[0] as string, 10);
+    const rows =
+      Number.isInteger(count) && count > 0
+        ? Math.min(count, MAX_PIECEWISE_ROWS)
+        : 1;
+
+    return makeEnvironment(
+      'cases',
+      Array.from({ length: rows }, () => [
+        [new PlaceholderAtom()],
+        [new PlaceholderAtom()],
+      ])
+    );
+  },
+});
 
 // This is a text mode environment
 /*

--- a/src/latex-commands/functions.ts
+++ b/src/latex-commands/functions.ts
@@ -574,7 +574,7 @@ function createBoundedOperator(
 // These command definitions intentionally come after the general operator
 // definitions above so they override only the parser for the three commands;
 // bare `\\int`, `\\sum`, and `\\prod` retain their normal rendering.
-defineFunction(['int', 'sum', 'prod'], '', {
+defineFunction(['int', 'sum', 'prod'], '{lower:expression}{upper:expression}', {
   ifMode: 'math',
   parse: parseBoundedOperator,
   createAtom: (options) =>

--- a/src/latex-commands/functions.ts
+++ b/src/latex-commands/functions.ts
@@ -13,6 +13,7 @@ import type { LatexValue } from '../public/core-types';
 import { Context } from '../core/context';
 import { Box } from '../core/box';
 import { OperatorAtom } from '../atoms/operator';
+import { BoundedArgumentAtom } from '../atoms/bounded-argument';
 import type { CreateAtomOptions } from 'core/types';
 import type { Argument } from './types';
 
@@ -518,4 +519,69 @@ defineFunction('the', '{:value}', {
   },
   serialize: (atom) =>
     `\\the${serializeLatexValue(atom.args![0] as LatexValue) ?? '\\relax'}`,
+});
+
+/**
+ * Parse the app-friendly bounded operator form `\\int{x}{y}` (and its
+ * `\\sum`/`\\prod` equivalents) without changing the standard bare command.
+ * Braced arguments are deliberately recognized only when the first argument
+ * starts immediately after the command; otherwise `\\int x` remains the
+ * ordinary unbounded integral followed by `x`.
+ */
+function parseBoundedOperator(parser: import('../core/parser').Parser): Argument[] {
+  if (parser.peek() !== '<{>') return [];
+
+  const lower = parser.scanArgument('expression');
+  if (!lower) return [];
+  if (parser.peek() !== '<{>') return [lower];
+
+  const upper = parser.scanArgument('expression');
+  return upper ? [lower, upper] : [lower];
+}
+
+function createBoundedOperator(
+  symbol: string,
+  options: CreateAtomOptions,
+): ExtensibleSymbolAtom {
+  const atom = new ExtensibleSymbolAtom(symbol, {
+    ...options,
+    limits: 'auto',
+    variant: 'main',
+  });
+  // Prevent the parser from preserving `\\int{x}{y}` verbatim; the
+  // structured bounds should be serialized as ordinary LaTeX bounds.
+  atom.verbatimLatex = null as unknown as undefined;
+  const [lower, upper] = options.args ?? [];
+  (atom as ExtensibleSymbolAtom & {
+    boundedArgumentSlots?: { subscript?: boolean; superscript?: boolean };
+  }).boundedArgumentSlots = {
+    subscript: Boolean(lower),
+    superscript: Boolean(upper),
+  };
+  if (lower)
+    atom.setChildren(
+      [new BoundedArgumentAtom(argAtoms(lower), options)],
+      'subscript',
+    );
+  if (upper)
+    atom.setChildren(
+      [new BoundedArgumentAtom(argAtoms(upper), options)],
+      'superscript',
+    );
+  return atom;
+}
+
+// These command definitions intentionally come after the general operator
+// definitions above so they override only the parser for the three commands;
+// bare `\\int`, `\\sum`, and `\\prod` retain their normal rendering.
+defineFunction(['int', 'sum', 'prod'], '', {
+  ifMode: 'math',
+  parse: parseBoundedOperator,
+  createAtom: (options) =>
+    createBoundedOperator(
+      { int: '\u222b', sum: '\u2211', prod: '\u220f' }[
+        options.command!.slice(1)
+      ]!,
+      options,
+    ),
 });

--- a/src/public/virtual-keyboard.ts
+++ b/src/public/virtual-keyboard.ts
@@ -60,6 +60,7 @@ export interface VirtualKeyboardKeycap {
    *    define the label.
    * - `shift`: a shift key
    * - `small`: display the label in a smaller size
+   * - `compact`: scale a structured label to fit inside the keycap
    * - `action`: an “action” keycap (for arrows, return, etc…)
    * - `separator w5`: a half-width blank used as a separator. Other widths
    *    include `w15` (1.5 width), `w20` (double width) and `w50` (five-wide,

--- a/test/latex.test.ts
+++ b/test/latex.test.ts
@@ -4,6 +4,7 @@ import {
 } from '../src/public/mathlive-ssr';
 import { parseLatex } from '../src/core/parser';
 import { Atom } from '../src/core/atom-class';
+import { ArrayAtom } from '../src/atoms/array';
 
 function markupAndError(formula: string): [string, string] {
   const markup = convertLatexToMarkup(formula, { defaultMode: 'math' });
@@ -137,6 +138,38 @@ describe('VARIANT SERIALIZATION (issue #2867)', () => {
     ['\\mathbb{N}_{abc}', '\\mathbb{N}_{abc}'],
   ])('%#/ %p serializes as %p', (input, expected) => {
     expect(serialize(input)).toBe(expected);
+  });
+});
+
+describe('PIECEWISE COMMAND', () => {
+  function serialize(latex: string): string {
+    const atoms = parseLatex(latex, { parseMode: 'math' });
+    return Atom.serialize(atoms, { defaultMode: 'math' });
+  }
+
+  test.each([2, 3])('creates %p editable rows', (rows) => {
+    const atom = parseLatex(`\\piecewise{${rows}}`)[0];
+    expect(atom).toBeInstanceOf(ArrayAtom);
+    expect((atom as ArrayAtom).rowCount).toBe(rows);
+
+    let placeholders = 0;
+    (atom as ArrayAtom).forEachCell((cell) => {
+      placeholders += cell.filter((x) => x.type === 'placeholder').length;
+    });
+    expect(placeholders).toBe(rows * 2);
+    expect(serialize(`\\piecewise{${rows}}`)).toBe(
+      `\\begin{cases}${Array.from(
+        { length: rows },
+        () => `\\placeholder{} & \\placeholder{}`
+      ).join('\\\\ ')}\\end{cases}`
+    );
+  });
+
+  test('validates the command', () => {
+    expect(validateLatex('\\piecewise{2}')).toHaveLength(0);
+    expect(validateLatex('\\piecewise')[0]?.code).toBe('missing-argument');
+    expect(validateLatex('\\piecewise{0}')[0]?.code).toBe('unexpected-token');
+    expect(validateLatex('\\piecewise{2a}')[0]?.code).toBe('unexpected-token');
   });
 });
 

--- a/test/latex.test.ts
+++ b/test/latex.test.ts
@@ -5,6 +5,7 @@ import {
 import { parseLatex } from '../src/core/parser';
 import { Atom } from '../src/core/atom-class';
 import { ArrayAtom } from '../src/atoms/array';
+import { getDefinition } from '../src/latex-commands/definitions-utils';
 
 function markupAndError(formula: string): [string, string] {
   const markup = convertLatexToMarkup(formula, { defaultMode: 'math' });
@@ -170,6 +171,31 @@ describe('PIECEWISE COMMAND', () => {
     expect(validateLatex('\\piecewise')[0]?.code).toBe('missing-argument');
     expect(validateLatex('\\piecewise{0}')[0]?.code).toBe('unexpected-token');
     expect(validateLatex('\\piecewise{2a}')[0]?.code).toBe('unexpected-token');
+  });
+});
+
+describe('BOUNDED OPERATOR COMMANDS', () => {
+  function serialize(latex: string): string {
+    const atoms = parseLatex(latex, { parseMode: 'math' });
+    return Atom.serialize(atoms, { defaultMode: 'math' });
+  }
+
+  test.each([
+    ['\\int{x}{y}', '\\int_{x}^{y}'],
+    ['\\sum{x}{y}', '\\sum_{x}^{y}'],
+    ['\\prod{x}{y}', '\\prod_{x}^{y}'],
+  ])('%#/ expands %p to %p', (input, expected) => {
+    expect(serialize(input)).toBe(expected);
+  });
+
+  test('registers the bounded parser for all three commands', () => {
+    for (const command of ['\\int', '\\sum', '\\prod']) {
+      expect(getDefinition(command, 'math')?.parse).toBeDefined();
+    }
+  });
+
+  test.each(['\\int x', '\\sum x', '\\prod x'])('%#/ preserves bare %p', (input) => {
+    expect(serialize(input)).toBe(input);
   });
 });
 

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -291,6 +291,21 @@ test('test inline shortcuts', async ({ page }) => {
   ).toBe(String.raw`\pm\nabla\cdot\alpha+\tan x-20\ge40`);
 });
 
+test('piecewise command creates editable rows', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+
+  await page.locator('#mf-1').pressSequentially(String.raw`\piecewise{2}`);
+  await page.locator('#mf-1').press('ArrowRight');
+
+  expect(
+    await page
+      .locator('#mf-1')
+      .evaluate((e: MathfieldElement) => e.getValue('latex-expanded'))
+  ).toBe(
+    String.raw`\begin{cases}\placeholder{} & \placeholder{}\\ \placeholder{} & \placeholder{}\end{cases}`
+  );
+});
+
 test('underscore subscript', async ({ page }) => {
   await page.goto('/dist/playwright-test-page/');
 

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -306,6 +306,40 @@ test('piecewise command creates editable rows', async ({ page }) => {
   );
 });
 
+test('LaTeX commands remain editable inside piecewise placeholders', async ({
+  page,
+}) => {
+  await page.goto('/dist/playwright-test-page/');
+  const field = page.locator('#mf-1');
+
+  await field.evaluate((mfe: MathfieldElement) => {
+    mfe.setValue(String.raw`\piecewise{2}`, {
+      format: 'latex',
+      selectionMode: 'placeholder',
+    });
+    mfe.focus();
+  });
+
+  await field.pressSequentially(String.raw`\alpha`);
+
+  const pending = await field.evaluate((mfe: MathfieldElement) => ({
+    mode: mfe.mode,
+    latex: mfe.getValue('latex'),
+  }));
+  expect(pending.mode).toBe('latex');
+  expect(pending.latex).toContain('\\begin{cases}');
+  expect(pending.latex).not.toContain('\\alpha');
+
+  await field.press('Space');
+
+  const completed = await field.evaluate((mfe: MathfieldElement) => ({
+    mode: mfe.mode,
+    latex: mfe.getValue('latex'),
+  }));
+  expect(completed.mode).toBe('math');
+  expect(completed.latex).toContain('\\alpha');
+});
+
 test('underscore subscript', async ({ page }) => {
   await page.goto('/dist/playwright-test-page/');
 

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -294,16 +294,51 @@ test('test inline shortcuts', async ({ page }) => {
 test('piecewise command creates editable rows', async ({ page }) => {
   await page.goto('/dist/playwright-test-page/');
 
-  await page.locator('#mf-1').pressSequentially(String.raw`\piecewise{2}`);
-  await page.locator('#mf-1').press('ArrowRight');
+  const field = page.locator('#mf-1');
+  await field.pressSequentially(String.raw`\piecewise{2}`);
 
   expect(
-    await page
-      .locator('#mf-1')
-      .evaluate((e: MathfieldElement) => e.getValue('latex-expanded'))
+    await field.evaluate((e: MathfieldElement) => ({
+      mode: e.mode,
+      latex: e.getValue('latex-expanded'),
+    }))
+  ).toEqual({
+    mode: 'math',
+    latex: String.raw`\begin{cases}\placeholder{} & \placeholder{}\\ \placeholder{} & \placeholder{}\end{cases}`,
+  });
+
+  await field.press('ArrowRight');
+
+  expect(
+    await field.evaluate((e: MathfieldElement) => e.getValue('latex-expanded'))
   ).toBe(
     String.raw`\begin{cases}\placeholder{} & \placeholder{}\\ \placeholder{} & \placeholder{}\end{cases}`
   );
+});
+
+test('bounded operator shortcuts complete after their final argument', async ({
+  page,
+}) => {
+  await page.goto('/dist/playwright-test-page/');
+  const field = page.locator('#mf-1');
+
+  for (const [command, expected] of [
+    ['int', String.raw`\int_{x}^{y}`],
+    ['sum', String.raw`\sum_{x}^{y}`],
+    ['prod', String.raw`\prod_{x}^{y}`],
+  ] as const) {
+    await field.evaluate((e: MathfieldElement) => {
+      e.value = '';
+      e.focus();
+    });
+    await field.pressSequentially(`\\${command}{x}{y}`);
+    expect(
+      await field.evaluate((e: MathfieldElement) => ({
+        mode: e.mode,
+        latex: e.getValue('latex-expanded'),
+      }))
+    ).toEqual({ mode: 'math', latex: expected });
+  }
 });
 
 test('LaTeX commands remain editable inside piecewise placeholders', async ({

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -601,6 +601,40 @@ test('bounded operator arguments remain editable after deletion', async ({ page 
   }
 });
 
+test('bounded operators delete body, bounds, then the operator', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+  const field = page.locator('#mf-1');
+
+  for (const command of ['int', 'sum', 'prod']) {
+    await field.evaluate((mfe: MathfieldElement, operator: string) => {
+      mfe.setValue(`\\${operator}{x}{y}z`, { format: 'latex' });
+      mfe.position = mfe.lastOffset;
+      mfe.focus();
+    }, command);
+
+    await field.press('Backspace');
+    expect(await field.evaluate((mfe: MathfieldElement) => mfe.getValue('latex'))).toBe(
+      `\\${command}_{x}^{y}`,
+    );
+
+    await field.press('Backspace');
+    await field.press('Backspace');
+    expect(await field.evaluate((mfe: MathfieldElement) => mfe.getValue('latex'))).toBe(
+      `\\${command}_{\\placeholder{}}^{y}`,
+    );
+
+    await field.press('Backspace');
+    await field.press('Backspace');
+    expect(await field.evaluate((mfe: MathfieldElement) => mfe.getValue('latex'))).toBe(
+      `\\${command}_{\\placeholder{}}^{\\placeholder{}}`,
+    );
+
+    await field.press('Backspace');
+    await field.press('Backspace');
+    expect(await field.evaluate((mfe: MathfieldElement) => mfe.getValue('latex'))).toBe('');
+  }
+});
+
 test('backspace on empty displaylines (issue #2739)', async ({ page }) => {
   await page.goto('/dist/playwright-test-page/');
 

--- a/test/playwright-tests/physical-keyboard.spec.ts
+++ b/test/playwright-tests/physical-keyboard.spec.ts
@@ -553,6 +553,54 @@ test('mathbb with superscript (issue #2867)', async ({ page }) => {
   expect(latex).toBe('\\mathbb{R}^0');
 });
 
+test('text-mode LaTeX commands wait for completion', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+  const field = page.locator('#mf-1');
+
+  await field.evaluate((mfe: MathfieldElement) => {
+    mfe.value = '';
+    mfe.mode = 'text';
+    mfe.focus();
+  });
+  await field.pressSequentially('\\pi');
+
+  const prefixState = await field.evaluate((mfe: MathfieldElement) => ({
+    mode: mfe.mode,
+    latex: mfe.getValue('latex'),
+  }));
+  expect(prefixState.mode).toBe('latex');
+  // An incomplete LaTeX group is intentionally not part of the public value
+  // yet; the important guarantee is that the field remains in command mode
+  // instead of committing `\\pi` as a symbol.
+  expect(prefixState.latex).toBe('');
+
+  await field.pressSequentially('ecewise{3}');
+  await field.press('Space');
+  expect(await field.evaluate((mfe: MathfieldElement) => mfe.getValue('latex')))
+    .toContain('\\begin{cases}');
+});
+
+test('bounded operator arguments remain editable after deletion', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+  const field = page.locator('#mf-1');
+  for (const command of ['int', 'sum', 'prod']) {
+    await field.evaluate((mfe: MathfieldElement, operator: string) => {
+      mfe.setValue(`\\${operator}{x}{y}`, { format: 'latex' });
+      mfe.position = mfe.lastOffset;
+      mfe.focus();
+    }, command);
+    await field.press('Backspace');
+    await field.press('Backspace');
+
+    const latex = await field.evaluate((mfe: MathfieldElement) => ({
+      latex: mfe.getValue('latex'),
+      expanded: mfe.getValue('latex-expanded'),
+    }));
+    expect(latex.latex).toContain(`\\${command}`);
+    expect(latex.expanded).toContain('\\placeholder{}');
+  }
+});
+
 test('backspace on empty displaylines (issue #2739)', async ({ page }) => {
   await page.goto('/dist/playwright-test-page/');
 

--- a/test/playwright-tests/virtual-keyboard.spec.ts
+++ b/test/playwright-tests/virtual-keyboard.spec.ts
@@ -243,3 +243,33 @@ test('Switch layer by shift', async ({ page }) => {
     .evaluate((mfe: MathfieldElement) => mfe.value);
   expect(latex).toBe('Aa');
 });
+
+test('compact keycap scales structured labels', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+  await page.locator('#mf-1').click();
+  await page.waitForFunction(() => Boolean(window.mathVirtualKeyboard));
+
+  await page.evaluate(() => {
+    window.mathVirtualKeyboard.layouts = [
+      {
+        label: 'compact',
+        rows: [
+          [
+            {
+              latex: String.raw`\begin{cases}#@ & #? \\ #@ & #?\end{cases}`,
+              class: 'compact',
+            },
+          ],
+        ],
+      },
+    ];
+  });
+
+  await page.locator('.ML__virtual-keyboard-toggle').nth(0).click();
+  const keycap = page.locator('.MLK__layer.is-visible .MLK__keycap.compact');
+  await expect(keycap).toBeVisible();
+  await expect(keycap.locator('.ML__latex')).toHaveCSS(
+    'transform',
+    'matrix(0.72, 0, 0, 0.72, 0, 0)'
+  );
+});

--- a/test/playwright-tests/virtual-keyboard.spec.ts
+++ b/test/playwright-tests/virtual-keyboard.spec.ts
@@ -256,7 +256,7 @@ test('compact keycap scales structured labels', async ({ page }) => {
         rows: [
           [
             {
-              latex: String.raw`\begin{cases}#@ & #? \\ #@ & #?\end{cases}`,
+              latex: String.raw`\begin{cases}#@ & #? \cr #@ & #?\end{cases}`,
               class: 'compact',
             },
           ],
@@ -272,4 +272,34 @@ test('compact keycap scales structured labels', async ({ page }) => {
     'transform',
     'matrix(0.72, 0, 0, 0.72, 0, 0)'
   );
+});
+
+test('virtual keyboard inserts editable piecewise rows', async ({ page }) => {
+  await page.goto('/dist/playwright-test-page/');
+  await page.locator('#mf-1').click();
+
+  await page.evaluate(() => {
+    window.mathVirtualKeyboard.layouts = [
+      {
+        label: 'piecewise',
+        rows: [
+          [
+            {
+              latex: String.raw`\begin{cases}#@ & #? \cr #@ & #?\end{cases}`,
+              class: 'compact',
+            },
+          ],
+        ],
+      },
+    ];
+  });
+
+  await page.locator('.ML__virtual-keyboard-toggle').nth(0).click();
+  await page.locator('.MLK__layer.is-visible .MLK__keycap.compact').click();
+
+  const latex = await page
+    .locator('#mf-1')
+    .evaluate((mfe: MathfieldElement) => mfe.getValue('latex-expanded'));
+  expect(latex).toContain('\\begin{cases}');
+  expect(latex.match(/\\placeholder\{\}/g)).toHaveLength(4);
 });


### PR DESCRIPTION
## What

Adds configurable piecewise and bounded-operator LaTeX shortcuts while preserving normal MathLive editing behavior:

- `\piecewise{n}` creates an editable native `cases` structure with `n` rows.
- `\int{x}{y}`, `\sum{x}{y}`, and `\prod{x}{y}` create bounded operators.
- Deleting content from a bounded lower or upper argument leaves an editable `\placeholder{}` instead of removing the bound.
- After the body and both bounds are cleared, Backspace traverses to the operator and removes it cleanly instead of getting stuck at the leading sentinel.
- Text-mode LaTeX commands now wait for completion instead of eagerly committing a prefix. For example, typing `\piecewise` no longer commits `\pi` while the command is incomplete.
- Adds the compact virtual-keyboard keycap class for tall structured labels.

## Why

MathLive users need parameterized structural shortcuts that remain editable after insertion. Prefix commands must also behave like ordinary LaTeX input: a shared prefix should remain pending until the command is complete or explicitly finalized. Structural deletion must preserve editable placeholders without making an empty operator impossible to remove.

## Implementation

- Registers a parameterized `piecewise` parser that builds the same native cases-array structure used by regular editing.
- Registers bounded parsers for `int`, `sum`, and `prod` while preserving their existing unbounded forms.
- Uses editable bounded argument atoms and deletion handling to retain placeholders when bound contents are removed.
- Removes an empty bounded operator only after its body, lower bound, and upper bound have been traversed.
- Defers the backslash in text mode into LaTeX command mode through the native keybinding definitions.
- Prevents custom structured commands from being serialized as opaque verbatim source.
- Keeps the compact keycap styling generic and independent of inserted LaTeX.

## Verification

- `npx tsc --noEmit -p tsconfig.json` — passed.
- `npx jest test/ --runInBand` — 344 tests passed.
- Focused Chromium Playwright coverage for piecewise insertion, deferred text-mode commands, bounded placeholder deletion, and full bounded-operator deletion order — passed.
- Focused Chromium Playwright coverage for compact structured virtual-keyboard labels — passed.
- NDQ full suite — 255 tests passed; targeted adapter follow-up — 15 tests passed.
- Skillboard MathLive integration tests — 3 passed; production build passed.
- Parse Tree production build passed.

The branch remains draft while the behavior is reviewed.