### PR TITLE
fix: Enable user selection for math static elements

### DIFF
--- a/css/core.less
+++ b/css/core.less
@@ -385,8 +385,6 @@
   white-space: nowrap;
 
   text-shadow: none;
-  -webkit-user-select: none;
-  user-select: none;
 
   width: min-content;
 

--- a/src/public/math-static-elements.ts
+++ b/src/public/math-static-elements.ts
@@ -396,6 +396,8 @@ abstract class MathStaticElement extends HTMLElement {
       if (!this._mathMLContainer) {
         this._mathMLContainer = document.createElement('div');
         this._mathMLContainer.style.position = 'absolute';
+        this._mathMLContainer.style.webkitUserSelect = 'none';
+        this._mathMLContainer.style.userSelect = 'none';
         this._mathMLContainer.style.width = '1px';
         this._mathMLContainer.style.height = '1px';
         this._mathMLContainer.style.overflow = 'hidden';


### PR DESCRIPTION
I would like to enable user selection on `<math-span />` and `<math-div />` elements.

To do this, I removed `user-select: none` from the `.ML__latex` CSS class in [core.less](css/core.less), so users can now select and copy the math content.

But this had a side effect: the `_mathMLContainer` (a hidden MathML element used for screen readers/accessibility) also became selectable, causing the same math expression to be duplicated when copied. To fix this, I added `user-select: none` directly on `_mathMLContainer` in [math-static-elements.ts](src/public/math-static-elements.ts), so only that element is excluded from selection/copy while the visible math stays selectable.