### PR TITLE
Update Compute Engine dependency to 0.120.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.110.0",
       "license": "MIT",
       "dependencies": {
-        "@cortex-js/compute-engine": "0.58.0"
+        "@cortex-js/compute-engine": "0.120.0"
       },
       "devDependencies": {
         "@arnog/esbuild-plugin-less": "^1.1.0",
@@ -581,17 +581,19 @@
       "license": "MIT"
     },
     "node_modules/@cortex-js/compute-engine": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.58.0.tgz",
-      "integrity": "sha512-N0+vXjVZfKwJS7ZIGvq41mojI55m5TrdDXveAXzNjzjZ9iNiNrdEzXL2EmrcP+9GCWCwTonrEeZWAIG78f3INg==",
+      "version": "0.120.0",
+      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.120.0.tgz",
+      "integrity": "sha512-CVFRjHdPU5MYl1lu+hNldT/KavKl2OYA+kKBBtlCPM0/D5vhfGEJQwwCdwDwcZFOF/w65uS+4lxl1qnDGcmmjA==",
       "license": "MIT",
       "dependencies": {
         "@arnog/colors": "^0.5.0",
-        "complex-esm": "^2.1.1-esm1",
-        "decimal.js": "^10.6.0"
+        "complex-esm": "^2.1.1-esm1"
+      },
+      "bin": {
+        "epsil": "dist/esm-min/cli/epsil.js"
       },
       "engines": {
-        "node": ">=21.7.3",
+        "node": ">=22.3.0",
         "npm": ">=10.5.0"
       }
     },
@@ -4188,12 +4190,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
   },
   "prettier": "@cortex-js/prettier-config",
   "dependencies": {
-    "@cortex-js/compute-engine": "0.58.0"
+    "@cortex-js/compute-engine": "0.120.0"
   },
   "devDependencies": {
     "@arnog/esbuild-plugin-less": "^1.1.0",


### PR DESCRIPTION
*This code and PR description is from a coding agent.*

## Summary

Update `@cortex-js/compute-engine` from `0.58.0` to `0.120.0` and refresh the lockfile.

## Why

When an application uses Compute Engine 0.120.0, MathLive's exact 0.58.0 dependency installs a second version. TypeScript then rejects assigning the application's engine to `MathfieldElement.computeEngine` because the two public types resolve from different versions.

This overlaps #3033, which proposes updating to 0.59.0. I kept MathLive's existing exact-version policy here.

Would you prefer this direct update, or should Compute Engine become a peer dependency so MathLive and its consumers share one version? I am happy to change direction.

## Testing

- production build passed
- 334 unit tests and 252 snapshots passed
- public declaration test passed
- packed consumer passed strict TypeScript 7, Vite, Chromium, and WebKit checks with one Compute Engine installation
